### PR TITLE
fix typo in fcitx-fbterm-9999

### DIFF
--- a/app-i18n/fcitx-fbterm/fcitx-fbterm-9999.ebuild
+++ b/app-i18n/fcitx-fbterm/fcitx-fbterm-9999.ebuild
@@ -19,7 +19,7 @@ IUSE=""
 DEPEND="app-i18n/fcitx
 	sys-devel/gettext"
 RDEPEND="${DEPEND}
-	app-18n/fbterm"
+	app-i18n/fbterm"
 
 src_unpack() {
 	git-2_src_unpack


### PR DESCRIPTION
when i edited the ebuild, a rather silly typo slipped in. sorry for the inconvenience :-(
