### PR TITLE
patch for media-video/deepin-media-player

### DIFF
--- a/media-video/deepin-media-player/deepin-media-player-1.201211151414.ebuild
+++ b/media-video/deepin-media-player/deepin-media-player-1.201211151414.ebuild
@@ -26,6 +26,9 @@ S=${WORKDIR}/${PN}-${MY_VER}
 src_prepare() {
 	rm -rf debian || die
 	rm locale/*.po* 
+
+	# add patch for mplayer binary name problem
+	epatch ${FILESDIR}/deepin-media-player-backend.patch
 }
 
 src_install() {

--- a/media-video/deepin-media-player/files/deepin-media-player-backend.patch
+++ b/media-video/deepin-media-player/files/deepin-media-player-backend.patch
@@ -1,0 +1,116 @@
+--- src/mplayer.py.old	2012-12-28 23:17:08.327921851 +0800
++++ src/mplayer.py	2012-12-28 23:39:07.765920127 +0800
+@@ -42,6 +42,12 @@
+ from type_check import is_valid_video_file, is_valid_url_file, is_file_can_play 
+ from ini import Config
+ 
++# get the backend name
++if os.path.exists('/usr/bin/mplayer2'):
++	BACKEND = "mplayer2"
++else:
++	BACKEND = "mplayer"
++
+ # play list state.
+ # 0: single playing.      
+ SINGLE_PLAYING_STATE = 0
+@@ -72,7 +78,7 @@
+ # Get play file length.
+ def get_length(file_path):
+     '''Get media player length.'''
+-    cmd = "mplayer -vo null -ao null -frames 0 -identify '%s'" % (file_path)
++    cmd = BACKEND+" -vo null -ao null -frames 0 -identify '%s'" % (file_path)
+     fp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+     cmd_str = fp.communicate()[0]
+     length_compile = re.compile(r"ID_LENGTH=([\d|\.]+)")
+@@ -85,7 +91,7 @@
+ def get_vide_width_height(file_path):
+     try:
+         if is_valid_video_file(file_path):
+-            cmd = "mplayer -vo null -ao null -frames 0 -identify '%s' 2>&1" % (file_path)
++            cmd = BACKEND+" -vo null -ao null -frames 0 -identify '%s' 2>&1" % (file_path)
+             fp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)    
+             cmd_str = fp.communicate()[0]
+             length_compile = re.compile(r"VIDEO:.+") 
+@@ -315,9 +321,7 @@
+         # player state.
+         # 0: single playing.      
+         # 1: order playing.     
+-        # 2: random player.      
+-        # 3: single cycle player. 
+-        # 4: list recycle play. 
++        # 2: random player.      # 3: single cycle player.  # 4: list recycle play. 
+         self.play_list_state = SINGLE_PLAYING_STATE
+         self.subtitle_scale_value = 1.0        
+         
+@@ -326,7 +330,7 @@
+         if not (self.state): # STOPING_STATE
+             self.lenState = 1 
+             # -input file.. streme player.
+-            command = ['mplayer',
++            command = [BACKEND,
+                        '-vo',
+                        'gl,2,x11,xv',
+                        '-zoom',
+@@ -777,7 +781,7 @@
+         
+         if self.state == STARTING_STATE:
+             # scrot image.
+-            scrot_command = "cd ~/.config/deepin-media-player/buffer/ && mplayer -ss %s -noframedrop -nosound -vo png -frames 1 '%s' >/dev/null 2>&1" % (scrot_pos, self.path)
++            scrot_command = "cd ~/.config/deepin-media-player/buffer/ && "+BACKEND+" -ss %s -noframedrop -nosound -vo png -frames 1 '%s' >/dev/null 2>&1" % (scrot_pos, self.path)
+             os.system(scrot_command)
+             # modify image name or get image file.
+             save_image_path = get_home_path() + "/.config/deepin-media-player/buffer/"        # save image buffer dir.
+@@ -805,7 +809,7 @@
+             
+         if self.state == STARTING_STATE:
+             # scrot image.
+-            os.system("cd /tmp/buffer/ && mplayer -ss %s -noframedrop -nosound -vo png -frames 1 '%s' >/dev/null 2>&1" % (scrot_pos, self.path))
++            os.system("cd /tmp/buffer/ && "+BACKEND+" -ss %s -noframedrop -nosound -vo png -frames 1 '%s' >/dev/null 2>&1" % (scrot_pos, self.path))
+             # modify image name or get image file.
+             save_image_path = "/tmp/buffer/"        # save preview image buffer dir.    
+             image_list = os.listdir(save_image_path) # get dir all image.
+--- src/switch_audio/audio.py.old	2012-12-28 16:48:16.000000000 +0800
++++ src/switch_audio/audio.py	2012-12-28 23:58:07.650921826 +0800
+@@ -22,6 +22,11 @@
+ 
+ import os
+ import gobject
++if os.path.exists('/usr/bin/mplayer2'):
++        BACKEND = "mplayer2"
++else:
++        BACKEND = "mplayer"
++
+ 
+ class SwitchAudio(gobject.GObject):    
+     __gsignals__ = {
+@@ -38,7 +43,7 @@
+         # self.get_video_information(player_path)
+         
+     def get_video_information(self, video_path):
+-        cmd = "mplayer -identify -frames 5 -endpos 0 -vo null '%s'" % (video_path)
++        cmd = BACKEND+" -identify -frames 5 -endpos 0 -vo null '%s'" % (video_path)
+         pipe = os.popen(str(cmd))
+         
+         id_aid_id   = "ID_AUDIO_ID="
+--- src/video_information/gui.py.old	2012-12-28 16:48:16.000000000 +0800
++++ src/video_information/gui.py	2012-12-28 23:56:09.070927467 +0800
+@@ -35,6 +35,10 @@
+ import gtk
+ import gobject
+ 
++if os.path.exists('/usr/bin/mplayer2'):
++	BACKEND = "mplayer2"
++else:
++	BACKEND = "mplayer"
+ 
+ 
+ 
+@@ -93,7 +97,7 @@
+         self.code_information = CodeInFormation()
+ 
+ def get_video_information(video_path):    
+-    cmd = "mplayer -identify -frames 5 -endpos 0 -vo null  '%s'" % (video_path)
++    cmd = BACKEND+" -identify -frames 5 -endpos 0 -vo null  '%s'" % (video_path)
+     pipe = os.popen(str(cmd))
+     return video_string_to_information(pipe, video_path)
+     


### PR DESCRIPTION
deepin-media-player depend on mplayer2, but it just recognize the binary named mplayer. Add this patch for it to recognize /usr/bin/mplayer2
