### PR TITLE
[net-im/qtqq]: Add missing dependence dev-qt/qtsql and dev-qt/qtwebkit

### DIFF
--- a/net-im/qtqq/qtqq-0.8.2.ebuild
+++ b/net-im/qtqq/qtqq-0.8.2.ebuild
@@ -18,6 +18,8 @@ SLOT="0"
 KEYWORDS="amd64 x86"
 IUSE=""
 
-DEPEND="dev-qt/qtgui"
+DEPEND="dev-qt/qtgui
+       dev-qt/qtsql
+       dev-qt/qtwebkit"
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
[net-im/qtqq]: Add missing dependence dev-qt/qtsql and dev-qt/qtwebkit

[
    Add missing dependence dev-qt/qtsql and dev-qt/qtwebkit for net-im/qtqq
]
