### PR TITLE
Remove bashism from goagent-initd

### DIFF
--- a/net-proxy/goagent/files/goagent-initd
+++ b/net-proxy/goagent/files/goagent-initd
@@ -15,7 +15,7 @@ start() {
     ebegin "Starting GoAgent"
     start-stop-daemon --start --name goagent \
     $GOAGENT_PID --make-pid \
-    --exec python3 /opt/goagent/local/proxy.py &> $GOAGENT_LOG &
+    --exec python3 /opt/goagent/local/proxy.py > $GOAGENT_LOG 2>&1 &
     eend $?
 }
 


### PR DESCRIPTION
"&>" is bash-specific. I use dash as /bin/sh and it doesn't work.

Portage tree里的启动脚本都避免bashism的：

/etc/init.d # fgrep '2>&1' \* | wc -l
45
/etc/init.d # fgrep '&>' \* | wc -l
1              [这一个就是goagent]
