### PR TITLE
x11-plugins/pidgin-lwqq : prompt if pidgin-lwqq doesn't work

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-gentoo-zh-j
+gentoo-zh

--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,1 +1,1 @@
-gentoo-zh
+gentoo-zh-j

--- a/x11-plugins/pidgin-lwqq/pidgin-lwqq-0.1d.ebuild
+++ b/x11-plugins/pidgin-lwqq/pidgin-lwqq-0.1d.ebuild
@@ -37,3 +37,11 @@ src_configure(){
 	)
 	cmake-utils_src_configure
 }
+
+pkg_postinst(){
+	ewarn
+	ewarn "If your pidgin-lwqq installed via gentoo-zh donesn't work"
+	ewarn "Please clone the source code from https://github.com/xiehuc/pidgin-lwqq"
+	ewarn "build pidgin-lwqq manully, you can get help from README.md"
+	ewarn 
+}


### PR DESCRIPTION
The pidgin-lwqq installed from gentoo-zh doesn't work on my machine.

But it did work very well if I clone the src from https://github.com/xiehuc/pidgin-lwqq
and build it manully. I don't know why, but maybe this prompt will help somebody.
