### PR TITLE
add baidu pan  for linux

### DIFF
--- a/net-misc/bcloud/Manifest
+++ b/net-misc/bcloud/Manifest
@@ -1,0 +1,1 @@
+DIST bcloud-3.3.7.tar.gz 156798 SHA256 b75fd3bea6e3ea256f2bb208e2fdb945eebbf00b09acf3938f76d063845514c9

--- a/net-misc/bcloud/bcloud-3.3.7.ebuild
+++ b/net-misc/bcloud/bcloud-3.3.7.ebuild
@@ -1,0 +1,44 @@
+# Copyright 1999-2012 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v3
+# $Header: $
+
+EAPI=5
+
+inherit fdo-mime versionator eutils python gnome2-utils
+
+DESCRIPTION="Baidu Pan client for Linux Desktop users"
+HOMEPAGE="https://github.com/LiuLang/bcloud"
+
+SRC_URI="https://pypi.python.org/packages/source/b/bcloud/${P}.tar.gz"
+
+LICENSE="GPL3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND=">=dev-lang/python-3.3[sqlite]
+	dev-python/urllib3
+	dev-python/pygobject
+	dev-python/keyring
+	dev-python/dbus-python
+	x11-themes/gnome-icon-theme-symbolic"
+DEPEND=""
+
+S=${WORKDIR}/${P}
+
+pkg_setup() {
+	python_set_active_version 3.3
+}
+
+src_compile() {
+	python setup.py build
+}
+
+src_install() {
+	python setup.py install
+}
+
+pkg_postinst() {
+	fdo-mime_desktop_database_update
+	fdo-mime_mime_database_update
+	gnome2_icon_cache_update
+}

--- a/net-misc/bcloud/metadata.xml
+++ b/net-misc/bcloud/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<herd>bcloud</herd>
+	<maintainer>
+		<email>Liangzhaostrive@gmail.com</email>
+		<name>LiangZhao</name>
+	</maintainer>
+	<longdescription>
+		百度网盘linux客户端.
+	</longdescription>
+</pkgmetadata>


### PR DESCRIPTION
手动 
python setup.py build
python setup.py install
可以用 
但是写成ebuild脚本 有这个提示
open_wr:      /usr/lib64/python3.3/site-packages/bcloud/**init**.py
error: could not create '/usr/lib64/python3.3/site-packages/bcloud/**init**.py': Permission denied

> > > Completed installing bcloud-3.3.7 into /var/tmp/portage/net-misc/bcloud-3.3.7/image/
- --------------------------- ACCESS VIOLATION SUMMARY ---------------------------
- LOG FILE: "/var/log/sandbox/sandbox-13222.log"
