### PR TITLE
sys-kernel/e-sources: fix USE flag for Reiser4

### DIFF
--- a/sys-kernel/e-sources/e-sources-3.14.5-r2.ebuild
+++ b/sys-kernel/e-sources/e-sources-3.14.5-r2.ebuild
@@ -18,7 +18,7 @@ uksm_kernel_version="3.14.0"
 
 KEYWORDS="~x86 ~amd64 ~mips"
 
-SUPPORTED_USE="+additional +aufs +cjktty +ck +exfat +experimental +gentoo +imq +thinkpad +rerser4 +tuxonice +uksm"
+SUPPORTED_USE="+additional +aufs +cjktty +ck +exfat +experimental +gentoo +imq +thinkpad +reiser4 +tuxonice +uksm"
 UNSUPPORTED_USE="imq"
 
 UNIPATCH_EXCLUDE=""


### PR DESCRIPTION
... which has been silently misspelt since commit 642d84e.
