### PR TITLE
media-video/avplayer: hide portage error

### DIFF
--- a/media-video/avplayer/avplayer-9999.ebuild
+++ b/media-video/avplayer/avplayer-9999.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=6
 inherit cmake-utils git-r3
 
 DESCRIPTION="avplayer is a p2p video downloader and player"

--- a/media-video/avplayer/avplayer-9999.ebuild
+++ b/media-video/avplayer/avplayer-9999.ebuild
@@ -1,8 +1,8 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
-inherit cmake-utils git-r3
+EAPI=7
+inherit cmake git-r3
 
 DESCRIPTION="avplayer is a p2p video downloader and player"
 HOMEPAGE="http://avplayer.avplayer.org"

--- a/media-video/avplayer/avplayer-9999.ebuild
+++ b/media-video/avplayer/avplayer-9999.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS=""
 
-DEPEND=">=dev-libs/boost-1.49[threads,static-libs]
+DEPEND=">=dev-libs/boost-1.49[threads(+),static-libs(+)]
 		dev-libs/openssl
 		media-libs/libsdl"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
sudo eix-sync

```
[1] "gentoo-zh" /var/db/repos/gentoo-zh (cache: parse|ebuild*3.0.24#metadata-md5#metadata-flat#assign)
     Reading category 113|181 ( 62): media-video... * ERROR: media-video/avplayer-9999::gentoo-zh failed (depend phase):
 *   toolchain-funcs: EAPI 5 not supported
 *
 * Call stack:
 *                ebuild.sh, line 611:  Called source '/var/db/repos/gentoo-zh/media-video/avplayer/avplayer-9999.ebuild'
 *     avplayer-9999.ebuild, line   5:  Called inherit 'cmake-utils' 'git-r3'
 *                ebuild.sh, line 294:  Called __qa_source '/var/db/repos/gentoo/eclass/cmake-utils.eclass'
 *                ebuild.sh, line 109:  Called source '/var/db/repos/gentoo/eclass/cmake-utils.eclass'
 *       cmake-utils.eclass, line 120:  Called inherit 'toolchain-funcs' 'ninja-utils' 'flag-o-matic' 'multiprocessing' 'xdg-utils'
 *                ebuild.sh, line 294:  Called __qa_source '/var/db/repos/gentoo/eclass/toolchain-funcs.eclass'
 *                ebuild.sh, line 109:  Called source '/var/db/repos/gentoo/eclass/toolchain-funcs.eclass'
 *   toolchain-funcs.eclass, line  18:  Called die
 * The specific snippet of code:
 *   	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 *
 * If you need support, post the output of `emerge --info '=media-video/avplayer-9999::gentoo-zh'`,
 * the complete build log and the output of `emerge -pqv '=media-video/avplayer-9999::gentoo-zh'`.
 * Working directory: '/usr/lib/python3.11/site-packages'
 * S: '/avplayer-9999'

ebuild failed with status 1
     Reading category 113|181 ( 62): media-video...
cannot properly execute /var/db/repos/gentoo-zh/media-video/avplayer/avplayer-9999.ebuild
     Reading category 181|181 (100) Finished
```

Signed-off-by: peeweep <peeweep@0x0.ee>