### PR TITLE
net-proxy/dae: remove `app-arch/p7zip` from DEPEND

### DIFF
--- a/net-proxy/dae/dae-0.3.0.ebuild
+++ b/net-proxy/dae/dae-0.3.0.ebuild
@@ -22,7 +22,6 @@ RESTRICT="mirror"
 DEPEND="
 	app-alternatives/v2ray-geoip
 	app-alternatives/v2ray-geosite
-	app-arch/p7zip
 "
 RDEPEND="$DEPEND"
 BDEPEND="sys-devel/clang"


### PR DESCRIPTION
@st0nie 

> https://github.com/microcai/gentoo-zh/pull/3374#issuecomment-1605655934

查询了一下 [相关的文档](https://devmanual.gentoo.org/ebuild-writing/functions/src_unpack/index.html)，ebuild 解压 zip 文件确实是不需要 app-arch/p7zip 的，除非自定义了 src_unpack 函数，并使用 p7zip 解压 zip，src_unpack 的默认行为是使用 unzip 解压 zip 文件。

另外 [此处](https://devmanual.gentoo.org/ebuild-writing/functions/src_unpack/other-formats/index.html) 提到需要在 BDEPEND 中加上 `app-arch/unzip`，但是实测不需要，~~ebuild 会自动依赖 `app-arch/unzip`~~，所以此次 pr 只从 DEPEND 中移除了 `app-arch/p7zip`。