### PR TITLE
net-proxy/yass: add 1.8.0-r1 and 1.7.5-r1

### DIFF
--- a/net-proxy/yass/yass-1.7.5-r1.ebuild
+++ b/net-proxy/yass/yass-1.7.5-r1.ebuild
@@ -37,7 +37,7 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=off
 		-DUSE_BUILTIN_CA_BUNDLE_CRT=off
 		-DUSE_LIBCXX=on
-		-DENABLE_LTO=off
+		-DENABLE_GOLD=off
 		-DGUI=ON
 		-DCLI=OFF
 		-DSERVER=OFF

--- a/net-proxy/yass/yass-1.8.0-r1.ebuild
+++ b/net-proxy/yass/yass-1.8.0-r1.ebuild
@@ -37,7 +37,7 @@ src_configure() {
 		-DBUILD_SHARED_LIBS=off
 		-DUSE_BUILTIN_CA_BUNDLE_CRT=off
 		-DUSE_LIBCXX=on
-		-DENABLE_LTO=off
+		-DENABLE_GOLD=off
 		-DGUI=ON
 		-DCLI=OFF
 		-DSERVER=OFF


### PR DESCRIPTION
Don't use gold linker by default.

New gentoo profiles (aka 23.0) will enable ldflags which are not accepted by gold linker such as -Wl,-z,pack-relative-relocs.

And it is recommented to use clang to compile yass. For clang, linker lld will be used and lto will be enabled by default.