### PR TITLE
net-proxy/yass: add tcmalloc option

### DIFF
--- a/net-proxy/yass/metadata.xml
+++ b/net-proxy/yass/metadata.xml
@@ -9,6 +9,7 @@
 		<flag name="cli">Enable cli daemon</flag>
 		<flag name="server">Enable server daemon</flag>
 		<flag name="gui">Enable GUI Client</flag>
+		<flag name="tcmalloc">Enable tcmalloc</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">Chilledheart/yass</remote-id>

--- a/net-proxy/yass/yass-1.9.1-r2.ebuild
+++ b/net-proxy/yass/yass-1.9.1-r2.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~riscv ~x86"
 
-IUSE="+cli server +gui wayland"
+IUSE="+cli server +gui wayland +tcmalloc"
 
 RDEPEND="
 	app-misc/ca-certificates
@@ -53,6 +53,7 @@ src_configure() {
 		-DSERVER=$(usex server)
 		-DGUI=$(usex gui)
 		-DBUILD_TESTS=off
+		-DUSE_TCMALLOC=$(usex tcmalloc)
 		-DUSE_SYSTEM_MBEDTLS=on
 		-DUSE_SYSTEM_ZLIB=on
 		-DUSE_SYSTEM_CARES=on


### PR DESCRIPTION
Prepare for 1.9.2 release.

For now, USE_TCMALLOC option doesn't support many architectures except for amd64, arm64 and riscv64.