### PR TITLE
net-proxy/yass: add 1.11.2-r1, drop 1.11.2

### DIFF
--- a/net-proxy/yass/yass-1.11.2-r1.ebuild
+++ b/net-proxy/yass/yass-1.11.2-r1.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~arm ~arm64 ~loong ~mips ~riscv ~x86"
 
-IUSE="+cli server test +gui +gtk3 gtk4 qt5 qt6 wayland +tcmalloc mimalloc"
+IUSE="+cli server test +gui gtk3 gtk4 +qt5 qt6 wayland +tcmalloc mimalloc"
 
 # tested with FEATURES="-network-sandbox test"
 # tested with FEATURES="network-sandbox test"


### PR DESCRIPTION
make qt5 default instead of gtk3 to silence RequiredUseDefaults warning.

> RequiredUseDefaults: version 1.11.2: profile: 'default/linux/amd64/23.0/desktop' (154 total) failed REQUIRED_USE: exactly-one-of ( gtk3 gtk4 qt5 qt6 )