### PR TITLE
net-proxy/yass: add 1.11.4-r1, drop 1.11.4 (loong)

### DIFF
--- a/net-proxy/yass/files/no-blacklist-loongarch.patch
+++ b/net-proxy/yass/files/no-blacklist-loongarch.patch
@@ -1,0 +1,30 @@
+From 6a65a9d53cbcc031d96e747578e6a3479ffc2d3e Mon Sep 17 00:00:00 2001
+From: Keeyou <keeyou-cn@outlook.com>
+Date: Fri, 19 Jul 2024 10:54:45 +0800
+Subject: [PATCH] gtk4: no longer blacklist loong arch
+
+---
+ CMakeLists.txt | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1c56b38d..87af272b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2097,13 +2097,6 @@ elseif (GUI)
+       set(GUI off)
+     endif()
+ 
+-    # fix up for loongarch64 gtk support
+-    # see https://github.com/microcai/gentoo-zh/pull/4486
+-    if (USE_GTK4 AND CMAKE_SYSTEM_PROCESSOR STREQUAL "loongarch64")
+-      message(STATUS "Blacklist gtk4 for loongarch64 target")
+-      set(USE_GTK4 OFF)
+-    endif()
+-
+     if (GUI AND USE_GTK4)
+       pkg_check_modules(GTK4 gtk4)
+     endif()
+-- 
+2.45.2
+

--- a/net-proxy/yass/yass-1.11.4-r1.ebuild
+++ b/net-proxy/yass/yass-1.11.4-r1.ebuild
@@ -26,7 +26,6 @@ RESTRICT="!test? ( test )"
 
 REQUIRED_USE="
 	gui? ( ^^ ( gtk3 gtk4 qt5 qt6 ) )
-	loong? ( !gtk4 )
 	tcmalloc? ( !mimalloc )
 "
 
@@ -79,6 +78,10 @@ BDEPEND="
 	)
 	test? ( net-misc/curl )
 "
+
+PATCHES=(
+	"${FILESDIR}"/no-blacklist-loongarch.patch
+)
 
 src_prepare() {
 	cmake_src_prepare


### PR DESCRIPTION
After this patch, we remove loong from gtk4's blacklist.

Learning from gtk4's upstream change of 4.13.8 which disables
llvmpipe gpu render usage, yass now uses cairo gsk render only
until it meets gtk4 library with 4.13.8 fix.

> https://gitlab.gnome.org/GNOME/gtk/-/blob/main/NEWS?ref_type=heads
> Overview of Changes in 4.13.8, 20-02-2024
> GSK: Don't use the gpu renderers with llvmpipe

Signed-off-by: Keeyou <keeyou-cn@outlook.com>
