### PR TITLE
app-misc/yazi: keyword 0.4.2 for ~riscv

### DIFF
--- a/app-misc/yazi/yazi-0.4.2.ebuild
+++ b/app-misc/yazi/yazi-0.4.2.ebuild
@@ -394,7 +394,7 @@ LICENSE+="
 	CC0-1.0 ISC MIT MPL-2.0 Unicode-DFS-2016
 "
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~riscv"
 
 IUSE="+cli"
 


### PR DESCRIPTION
Tested in LicheePi 4 A