### PR TITLE
app-editors/cursor: add missing udev dep to 0.49.6

### DIFF
--- a/app-editors/cursor/cursor-0.49.6.ebuild
+++ b/app-editors/cursor/cursor-0.49.6.ebuild
@@ -30,6 +30,10 @@ IUSE="egl kerberos wayland"
 RESTRICT="bindist mirror strip"
 
 RDEPEND="
+	|| (
+		sys-apps/systemd
+		sys-apps/systemd-utils
+	)
 	>=app-accessibility/at-spi2-core-2.46.0:2
 	app-crypt/libsecret[crypt]
 	app-misc/ca-certificates


### PR DESCRIPTION
$ grep udev /var/db/pkg/app-editors/cursor-0.49.6/NEEDED

/opt/cursor/cursor libffmpeg.so,libdl.so.2,libpthread.so.0,libglib-2.0.so.0,libgobject-2.0.so.0,libgio-2.0.so.0,libnss3.so,libnssutil3.so,libsmime3.so,libnspr4.so,libdbus-1.so.3,libatk-1.0.so.0,libatk-bridge-2.0.so.0,libcups.so.2,libgtk-3.so.0,libpango-1.0.so.0,libcairo.so.2,libX11.so.6,libXcomposite.so.1,libXdamage.so.1,libXext.so.6,libXfixes.so.3,libXrandr.so.2,libgbm.so.1,libexpat.so.1,libxcb.so.1,libxkbcommon.so.0,libudev.so.1,libasound.so.2,libatspi.so.0,libm.so.6,libgcc_s.so.1,libc.so.6,ld-linux-x86-64.so.2