### PR TITLE
app-i18n/fcitx-skk: drop qt5

### DIFF
--- a/app-i18n/fcitx-skk/fcitx-skk-5.1.6.ebuild
+++ b/app-i18n/fcitx-skk/fcitx-skk-5.1.6.ebuild
@@ -38,6 +38,9 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+# cmake_minimum_required is 3.6.0
+CMAKE_QA_COMPAT_SKIP=1
+
 src_configure() {
 	local mycmakeargs=( )
 	if use qt5 || use qt6; then

--- a/app-i18n/fcitx-skk/fcitx-skk-5.1.7-r2.ebuild
+++ b/app-i18n/fcitx-skk/fcitx-skk-5.1.7-r2.ebuild
@@ -15,19 +15,13 @@ S="${WORKDIR}/${MY_PN}-${PV}"
 LICENSE="GPL-3+"
 SLOT="5"
 KEYWORDS="~amd64 ~x86"
-IUSE="+qt5 qt6"
-REQUIRED_USE="^^ ( qt5 qt6 )"
+IUSE="qt6"
 
 RDEPEND="
 	>=app-i18n/fcitx-5.1.13:5
-	app-i18n/fcitx-qt[qt5?,qt6?,-onlyplugin]
+	app-i18n/fcitx-qt[qt6?,-onlyplugin]
 	app-i18n/libskk
 	app-i18n/skk-jisyo
-	qt5? (
-		dev-qt/qtcore:5
-		dev-qt/qtgui:5=
-		dev-qt/qtwidgets:5
-	)
 	qt6? (
 		dev-qt/qtbase:6[dbus,gui,widgets]
 	)
@@ -40,10 +34,9 @@ BDEPEND="
 
 src_configure() {
 	local mycmakeargs=( )
-	if use qt5 || use qt6; then
+	if use qt6; then
 		mycmakeargs+=(
 			-DENABLE_QT=ON
-			-DUSE_QT6=$(usex qt6)
 		)
 	fi
 	cmake_src_configure

--- a/app-i18n/fcitx-skk/fcitx-skk-5.1.7-r2.ebuild
+++ b/app-i18n/fcitx-skk/fcitx-skk-5.1.7-r2.ebuild
@@ -32,6 +32,9 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+# cmake_minimum_required is 3.6.0
+CMAKE_QA_COMPAT_SKIP=1
+
 src_configure() {
 	local mycmakeargs=( )
 	if use qt6; then

--- a/app-i18n/fcitx-skk/fcitx-skk-9999.ebuild
+++ b/app-i18n/fcitx-skk/fcitx-skk-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Gentoo Authors
+# Copyright 2021-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -11,19 +11,13 @@ EGIT_REPO_URI="https://github.com/fcitx/fcitx5-skk"
 
 LICENSE="GPL-3+"
 SLOT="5"
-IUSE="+qt5 qt6"
-REQUIRED_USE="^^ ( qt5 qt6 )"
+IUSE="qt6"
 
 RDEPEND="
-	>=app-i18n/fcitx-5.1.6:5
-	app-i18n/fcitx-qt[qt5?,qt6?,-onlyplugin]
+	>=app-i18n/fcitx-5.1.13:5
+	app-i18n/fcitx-qt[qt6?,-onlyplugin]
 	app-i18n/libskk
 	app-i18n/skk-jisyo
-	qt5? (
-		dev-qt/qtcore:5
-		dev-qt/qtgui:5=
-		dev-qt/qtwidgets:5
-	)
 	qt6? (
 		dev-qt/qtbase:6[dbus,gui,widgets]
 	)
@@ -36,10 +30,9 @@ BDEPEND="
 
 src_configure() {
 	local mycmakeargs=( )
-	if use qt5 || use qt6; then
+	if use qt6; then
 		mycmakeargs+=(
 			-DENABLE_QT=ON
-			-DUSE_QT6=$(usex qt6)
 		)
 	fi
 	cmake_src_configure

--- a/app-i18n/fcitx-skk/fcitx-skk-9999.ebuild
+++ b/app-i18n/fcitx-skk/fcitx-skk-9999.ebuild
@@ -28,6 +28,9 @@ BDEPEND="
 	virtual/pkgconfig
 "
 
+# cmake_minimum_required is 3.6.0
+CMAKE_QA_COMPAT_SKIP=1
+
 src_configure() {
 	local mycmakeargs=( )
 	if use qt6; then


### PR DESCRIPTION
It seems to have been missed in previous updates.

cf. https://github.com/fcitx/fcitx5-skk/commit/0ebea29280753de2909abed6b3d958d14f451563