### PR TITLE
net-proxy/hysteria: move go to BDEPEND

### DIFF
--- a/net-proxy/hysteria/hysteria-2.6.5-r1.ebuild
+++ b/net-proxy/hysteria/hysteria-2.6.5-r1.ebuild
@@ -20,10 +20,12 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
+BDEPEND="
+	>=dev-lang/go-1.25.1
+"
 DEPEND="
 	acct-user/hysteria
 	acct-group/hysteria
-	>=dev-lang/go-1.25.1
 "
 RDEPEND="${DEPEND}"
 


### PR DESCRIPTION
If hysteria is installed from a binary package, there's no reason to install go with it