### PR TITLE
net-proxy/hysteria: systemd hardening, add template services

### DIFF
--- a/net-proxy/hysteria/files/hysteria-client.service
+++ b/net-proxy/hysteria/files/hysteria-client.service
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
+Restart=on-failure
 ExecStart=/usr/bin/hysteria client --config /etc/hysteria/client.yaml --disable-update-check
 WorkingDirectory=~
 User=hysteria
@@ -13,6 +14,19 @@ Environment=HYSTERIA_LOG_LEVEL=info
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=true
+
+# further hardening
+ProtectSystem=full
+ProtectHome=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectClock=yes
+ProtectProc=noaccess
+PrivateTmp=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/net-proxy/hysteria/files/hysteria-client_at.service
+++ b/net-proxy/hysteria/files/hysteria-client_at.service
@@ -1,11 +1,12 @@
 [Unit]
-Description=Hysteria Server Service
+Description=Hysteria Client Service
 Documentation=https://hysteria.network/
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/hysteria server --config /etc/hysteria/server.yaml --disable-update-check
+Restart=on-failure
+ExecStart=/usr/bin/hysteria client --config /etc/hysteria/%i.yaml --disable-update-check
 WorkingDirectory=~
 User=hysteria
 Group=hysteria
@@ -23,7 +24,6 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectClock=yes
 ProtectProc=noaccess
-PrivateDevices=yes
 PrivateTmp=yes
 RestrictNamespaces=yes
 RestrictSUIDSGID=yes

--- a/net-proxy/hysteria/files/hysteria-server_at.service
+++ b/net-proxy/hysteria/files/hysteria-server_at.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/hysteria server --config /etc/hysteria/server.yaml --disable-update-check
+ExecStart=/usr/bin/hysteria server --config /etc/hysteria/%i.yaml --disable-update-check
 WorkingDirectory=~
 User=hysteria
 Group=hysteria

--- a/net-proxy/hysteria/hysteria-2.6.5-r2.ebuild
+++ b/net-proxy/hysteria/hysteria-2.6.5-r2.ebuild
@@ -58,10 +58,23 @@ src_install() {
 
 	dobin "${PN}"
 
+	systemd_newunit "${FILESDIR}/${PN}-server_at.service" "${PN}-server@.service"
+	systemd_newunit "${FILESDIR}/${PN}-client_at.service" "${PN}-client@.service"
+	# compatibility services
 	systemd_dounit "${FILESDIR}/${PN}-server.service"
 	systemd_dounit "${FILESDIR}/${PN}-client.service"
+
 	newinitd "${FILESDIR}/${PN}-server.initd" "${PN}-server"
 	newinitd "${FILESDIR}/${PN}-client.initd" "${PN}-client"
 
 	keepdir /etc/${PN}
+}
+
+pkg_postinst() {
+	elog
+	elog "Systemd services are now templates, with a configuration file"
+	elog "name as a parameter. We recommend replacing: "
+	elog "  hysteria-server.service -> hysteria-server@server.service"
+	elog "  hysteria-client.service -> hysteria-client@client.service"
+	elog
 }


### PR DESCRIPTION
This PR hardens systemd services a bit, taking the `systemd-analyse security` score down from 6.* to around 4.*, and adds "@" services like in [arch linux](https://aur.archlinux.org/packages/hysteria)  (so it's easy to run multiple clients or servers, or use custom config file names)