### PR TITLE
net-proxy/smartproxy: update EAPI 7 -> 8

### DIFF
--- a/net-proxy/smartproxy/smartproxy-0.9.5.ebuild
+++ b/net-proxy/smartproxy/smartproxy-0.9.5.ebuild
@@ -1,15 +1,15 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit cmake
+
+# workaround for compatibility with cmake 4, bugs #951350
+CMAKE_QA_COMPAT_SKIP=yes
 
 DESCRIPTION="A fast, proxy smart selector"
 HOMEPAGE="https://github.com/microcai/smartproxy"
-
-EGIT_REPO_URI="https://github.com/microcai/smartproxy"
-EGIT_COMMIT="v${PV}"
-
-inherit cmake
 SRC_URI="
 	https://github.com/microcai/smartproxy/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 "
@@ -18,16 +18,14 @@ LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-RDEPEND="dev-libs/openssl
-"
-
-DEPEND="dev-libs/openssl
-"
+DEPEND="dev-libs/openssl"
+RDEPEND="${DEPEND}"
 
 src_configure(){
 	local mycmakeargs=(
 		-DUSE_SYSTEM_OPENSSL=ON
 		-DUSE_SYSTEM_BOOST=OFF
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 # bugs #951350
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
Part-of https://github.com/microcai/gentoo-zh/issues/8504