### PR TITLE
dev-python/uv-bin: add 0.9.13, drop 0.9.11, close #8731

### DIFF
--- a/dev-python/uv-bin/uv-bin-0.9.13.ebuild
+++ b/dev-python/uv-bin/uv-bin-0.9.13.ebuild
@@ -1,0 +1,38 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+inherit unpacker
+DESCRIPTION="An extremely fast Python package and project manager, written in Rust."
+HOMEPAGE="https://github.com/astral-sh/uv"
+URLPREFIX="https://github.com/astral-sh/uv/releases/download"
+SRC_URI="
+	amd64? (
+		elibc_glibc? ( ${URLPREFIX}/${PV}/uv-x86_64-unknown-linux-gnu.tar.gz -> ${P}-x86_64-unknown-linux-gnu.tar.gz )
+		elibc_musl? ( ${URLPREFIX}/${PV}/uv-x86_64-unknown-linux-musl.tar.gz  -> ${P}-x86_64-unknown-linux-musl.tar.gz )
+	)
+"
+
+S="${WORKDIR}"
+LICENSE="Apache-2.0 MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+RESTRICT="strip"
+DEPEND="
+	!dev-python/uv
+	elibc_glibc? ( sys-libs/glibc )
+	elibc_musl? ( sys-libs/musl )
+"
+RDEPEND="${DEPEND}"
+
+src_install() {
+	if use elibc_glibc ; then
+		dir="uv-x86_64-unknown-linux-gnu"
+	elif use elibc_musl ; then
+		dir="uv-x86_64-unknown-linux-musl"
+	else
+		die "Unsupported libc"
+	fi
+
+	dobin "${dir}/uv" "${dir}/uvx"
+}


### PR DESCRIPTION
Automated bump from nvchecker issue #8731

Version: 0.9.11 → 0.9.13

Closes #8731