### PR TITLE
sys-boot/ventoy-bin: fix QA Notice that Files built without respecting CFLAGS

### DIFF
--- a/sys-boot/ventoy-bin/ventoy-bin-1.1.09.ebuild
+++ b/sys-boot/ventoy-bin/ventoy-bin-1.1.09.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2023 Gentoo Authors
+# Copyright 2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -30,6 +30,8 @@ RDEPEND="
 "
 
 CARCH="x86_64"
+
+QA_PREBUILT="*"
 
 src_prepare() {
 	# Decompress tools


### PR DESCRIPTION
I had

```
 * QA Notice: Files built without respecting CFLAGS have been detected
 *  Please include the following list of files in your report:
 * /opt/ventoy/tool/x86_64/Ventoy2Disk.qt5
 * /opt/ventoy/tool/x86_64/mount.exfat-fuse
 * /opt/ventoy/tool/x86_64/vtoycli
 * /opt/ventoy/tool/x86_64/ash
 * /opt/ventoy/tool/x86_64/Ventoy2Disk.gtk3
 * /opt/ventoy/tool/x86_64/mkexfatfs
 * /opt/ventoy/tool/x86_64/Plugson
 * /opt/ventoy/tool/x86_64/V2DServer
 * /opt/ventoy/tool/x86_64/vtoygpt
 * /opt/ventoy/tool/x86_64/vlnk
 * /opt/ventoy/VentoyGUI.x86_64
``` 