### PR TITLE
net-misc/localsend-bin: unkeyword non supported arches

### DIFF
--- a/net-misc/localsend-bin/localsend-bin-1.17.0.ebuild
+++ b/net-misc/localsend-bin/localsend-bin-1.17.0.ebuild
@@ -16,7 +16,7 @@ S="${WORKDIR}"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64"
+KEYWORDS="-* ~amd64 ~arm64"
 
 RESTRICT="bindist"
 


### PR DESCRIPTION
@Nuralii1i pinging you as you are the maintainer