### PR TITLE
media-sound/netease-cloud-music: update dependencies

### DIFF
--- a/media-sound/netease-cloud-music/files/doinslib.list
+++ b/media-sound/netease-cloud-music/files/doinslib.list
@@ -8,10 +8,10 @@ libicudata.so.60
 libicui18n.so.60
 libicuuc.so.60
 libinput.so.10
+libjpeg.so.8
 libmtdev.so.1
 libnspr4.so
 libnss3.so
-libnssutil3.so
 libplc4.so
 libplds4.so
 libqcef.so
@@ -31,6 +31,7 @@ libQt5XcbQpa.so.5
 libQt5Xml.so.5
 libsmime3.so
 libsqlite3.so.0
+libtag.so.1
 libwacom.so.2
 libX11-xcb.so.1
 libxcb-glx.so.0

--- a/media-sound/netease-cloud-music/netease-cloud-music-1.2.1-r1.ebuild
+++ b/media-sound/netease-cloud-music/netease-cloud-music-1.2.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -9,24 +9,23 @@ DESCRIPTION="Netease Cloud Music, converted from .deb package"
 HOMEPAGE="https://music.163.com"
 SRC_URI="https://d1.music.126.net/dmusic/${PN}_${PV}_amd64_ubuntu_20190428.deb"
 
+S="${WORKDIR}"
 LICENSE="NetEase BSD"
 SLOT="0"
-RESTRICT="strip mirror"
 KEYWORDS="-* ~amd64"
+RESTRICT="strip mirror"
 
 DEPEND="media-video/vlc[taglib]"
 RDEPEND="${DEPEND}
+	dev-libs/nss
 	media-libs/alsa-lib
-	media-sound/pulseaudio
 	net-dns/avahi
 	net-libs/libgssglue
-	sys-auth/nss-mdns
 	sys-devel/binutils
-	virtual/jpeg:0
 	virtual/krb5
-	x11-libs/gtk+:3
+	x11-libs/gtk+:2
+	x11-libs/gtk+:3[X]
 "
-S="${WORKDIR}"
 
 QA_PREBUILT="opt/netease/${PN}/*"
 QA_FLAGS_IGNORED="opt/netease/${PN}/*"


### PR DESCRIPTION
Closes: https://github.com/microcai/gentoo-zh/issues/9162


<img width="1105" height="727" alt="image" src="https://github.com/user-attachments/assets/f63016c2-bd14-4490-b39a-5918eed23daf" />

无法联网不知道如何解决。尝试过 LD PRELOAD  添加 /usr/lib64/libgio-2.0.so 没有效果