### PR TITLE
games-arcade/osu-lazer-bin: fix typo

### DIFF
--- a/games-arcade/osu-lazer-bin/osu-lazer-bin-2026.102.1.ebuild
+++ b/games-arcade/osu-lazer-bin/osu-lazer-bin-2026.102.1.ebuild
@@ -58,7 +58,7 @@ src_prepare() {
 	# Remove pdb files
 	rm -fv *.pdb
 
-	# Remove UpdateNix from Velopack, updates are managed by protage
+	# Remove UpdateNix from Velopack, updates are managed by portage
 	rm -v UpdateNix || die
 
 	if use system-sdl; then

--- a/games-arcade/osu-lazer-bin/osu-lazer-bin-2026.119.0.ebuild
+++ b/games-arcade/osu-lazer-bin/osu-lazer-bin-2026.119.0.ebuild
@@ -58,7 +58,7 @@ src_prepare() {
 	# Remove pdb files
 	rm -fv *.pdb
 
-	# Remove UpdateNix from Velopack, updates are managed by protage
+	# Remove UpdateNix from Velopack, updates are managed by portage
 	rm -v UpdateNix || die
 
 	if use system-sdl; then

--- a/games-arcade/osu-lazer-bin/osu-lazer-bin-2026.209.0.ebuild
+++ b/games-arcade/osu-lazer-bin/osu-lazer-bin-2026.209.0.ebuild
@@ -57,7 +57,7 @@ src_prepare() {
 	# Remove pdb files
 	rm -fv *.pdb
 
-	# Remove UpdateNix from Velopack, updates are managed by protage
+	# Remove UpdateNix from Velopack, updates are managed by portage
 	rm -v UpdateNix || die
 
 	if use system-sdl; then


### PR DESCRIPTION
Fixed the typo "protage" to "portage"