### PR TITLE
virtual/dist-kernel: fix nonexistent deps for 6.19.10-r100

### DIFF
--- a/virtual/dist-kernel/dist-kernel-6.19.10-r100.ebuild
+++ b/virtual/dist-kernel/dist-kernel-6.19.10-r100.ebuild
@@ -10,8 +10,5 @@ KEYWORDS="~amd64"
 
 RDEPEND="
 	|| (
-		~sys-kernel/gentoo-kernel-${PV}
-		~sys-kernel/gentoo-kernel-bin-${PV}
-		~sys-kernel/vanilla-kernel-${PV}
 		~sys-kernel/xanmod-kernel-${PV}
 	)"


### PR DESCRIPTION
## Summary
- remove `gentoo-kernel`, `gentoo-kernel-bin`, and `vanilla-kernel` 6.19.10 providers from `virtual/dist-kernel-6.19.10-r100`
- keep only the existing `sys-kernel/xanmod-kernel-6.19.10` provider so pkgcheck no longer reports `NonexistentDeps`
- match the current CI failure in `pkgcheck` which exits on `NonexistentDeps`

## Verification
- `pkgcheck scan --checks=-RedundantVersionCheck --keywords=-NonsolvableDepsInDev --exit=NonexistentDeps virtual/dist-kernel`