### PR TITLE
dev-python/funasr-onnx: drop python3_11, fix NonsolvableDepsInStable

### DIFF
--- a/dev-python/funasr-onnx/funasr-onnx-0.4.1-r1.ebuild
+++ b/dev-python/funasr-onnx/funasr-onnx-0.4.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..13} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 


### PR DESCRIPTION
Stable-profile deps dropped python3_11; drop from PYTHON_COMPAT to clear pkgcheck's NonsolvableDepsInStable warning.