### PR TITLE
dev-python/librosa: drop python3_11, add python3_14

### DIFF
--- a/dev-python/librosa/librosa-0.11.0-r1.ebuild
+++ b/dev-python/librosa/librosa-0.11.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 PYPI_VERIFY_REPO="https://github.com/librosa/librosa"
 inherit distutils-r1 pypi


### PR DESCRIPTION
Stable-profile deps (joblib/scikit-learn/scipy) dropped python3_11 and now support python3_14; update PYTHON_COMPAT to match.