### PR TITLE
treewide: fix variable order

### DIFF
--- a/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.27-r1.ebuild
+++ b/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.27-r1.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://www.deepin.org"
 
 COMMON_URI="https://home-store-packages.uniontech.com/appstore/pool/appstore/d"
 SRC_URI="${COMMON_URI}/${PN}/${PN}_${PV}-${PR/r/}_i386.deb"
+S=${WORKDIR}
 
 LICENSE="LGPL-2.1"
 SLOT="0"
@@ -23,8 +24,6 @@ RDEPEND="
 	app-emulation/deepin-wine-plugin[virtual-pkg]
 "
 DEPEND="${RDEPEND}"
-
-S=${WORKDIR}
 
 QA_PREBUILT="opt/deepinwine/*"
 QA_FLAGS_IGNORED="opt/deepinwine/*"

--- a/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.45.ebuild
+++ b/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.45.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://www.deepin.org"
 
 COMMON_URI="https://home-store-packages.uniontech.com/appstore/pool/appstore/d"
 SRC_URI="${COMMON_URI}/${PN}/${PN}_${PV}-1_i386.deb"
+S=${WORKDIR}
 
 LICENSE="LGPL-2.1"
 SLOT="0"
@@ -22,8 +23,6 @@ RDEPEND="
 	${PYTHON_DEPS}
 "
 DEPEND="${RDEPEND}"
-
-S=${WORKDIR}
 
 QA_PREBUILT="opt/deepinwine/*"
 QA_FLAGS_IGNORED="opt/deepinwine/*"

--- a/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
+++ b/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
@@ -11,6 +11,7 @@ MY_PV="${MY_PV//_/-}"
 DESCRIPTION="A low latency KVMFR application for guests with VGA PCI Passthrough"
 HOMEPAGE="https://looking-glass.io"
 SRC_URI="https://looking-glass.io/artifact/${MY_PV}/source -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-${MY_PV}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -52,8 +53,6 @@ DEPEND="gui-libs/egl-wayland
 		media-video/obs-studio
 	)"
 RDEPEND="${DEPEND}"
-
-S="${WORKDIR}/${PN}-${MY_PV}"
 
 MY_CMAKE_PROJECT="client "
 

--- a/dev-embedded/at32workbench/at32workbench-1.2.03.ebuild
+++ b/dev-embedded/at32workbench/at32workbench-1.2.03.ebuild
@@ -6,6 +6,7 @@ EAPI=8
 DESCRIPTION="at32 workbench is a GUI tool for AT32 MCU startup code generation"
 HOMEPAGE="https://www.arterytek.com/cn/support/tools.jsp"
 SRC_URI="https://www.arterytek.com/download/AT32%20Workbench/AT32_Work_Bench_Linux-x86_64_V${PV}.zip"
+S="${WORKDIR}"
 
 LICENSE="all-rights-reserved"
 SLOT="0"
@@ -24,8 +25,6 @@ RDEPEND="${DEPEND}"
 BDEPEND=""
 
 inherit unpacker
-
-S="${WORKDIR}"
 
 src_unpack(){
 	unpack ${A}

--- a/dev-python/frozendict/frozendict-2.4.6.ebuild
+++ b/dev-python/frozendict/frozendict-2.4.6.ebuild
@@ -10,12 +10,11 @@ inherit distutils-r1
 DESCRIPTION="A simple immutable dictionary for Python"
 HOMEPAGE="https://github.com/Marco-Sulla/python-frozendict"
 SRC_URI="https://github.com/Marco-Sulla/python-frozendict/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/python-${PN}-${PV}"
 
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64"
-
-S="${WORKDIR}/python-${PN}-${PV}"
 
 BDEPEND="
 	$(python_gen_cond_dep 'dev-python/setuptools-scm[${PYTHON_USEDEP}]')

--- a/games-misc/oh-my-git-bin/oh-my-git-bin-0.6.5.ebuild
+++ b/games-misc/oh-my-git-bin/oh-my-git-bin-0.6.5.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://ohmygit.org/
 	https://github.com/git-learning-game/oh-my-git"
 PKG_URI="https://blinry.itch.io/oh-my-git"
 SRC_URI="${MY_PN}-linux.zip"
+S="${WORKDIR}"
 
 LICENSE="BlueOak-1.0.0"
 SLOT="0"
@@ -30,8 +31,6 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
-
-S="${WORKDIR}"
 
 pkg_nofetch() {
 	elog "Please download ${A} from"

--- a/media-gfx/zw3d/zw3d-2022.0.3.1-r3.ebuild
+++ b/media-gfx/zw3d/zw3d-2022.0.3.1-r3.ebuild
@@ -9,6 +9,7 @@ inherit unpacker xdg
 DESCRIPTION="CAD/CAM software for 3D design and processing"
 HOMEPAGE="https://www.zwsoft.cn/product/zw3d/linux"
 SRC_URI="https://home-store-packages.uniontech.com/appstore/pool/appstore/c/${MY_PGK_NAME}/${MY_PGK_NAME}_${PV}_amd64.deb -> ${P}.deb"
+S=${WORKDIR}
 
 LICENSE="all-rights-reserved"
 SLOT="0"
@@ -59,8 +60,6 @@ BDEPEND="
 	dev-util/bbe
 	dev-util/patchelf
 "
-
-S=${WORKDIR}
 
 QA_PREBUILT="*"
 

--- a/media-gfx/zw3d/zw3d-2023.0.3.1.ebuild
+++ b/media-gfx/zw3d/zw3d-2023.0.3.1.ebuild
@@ -9,6 +9,7 @@ inherit unpacker xdg
 DESCRIPTION="CAD/CAM software for 3D design and processing"
 HOMEPAGE="https://www.zwsoft.cn/product/zw3d/linux"
 SRC_URI="https://home-store-packages.uniontech.com/appstore/pool/appstore/c/${MY_PGK_NAME}/${MY_PGK_NAME}_${PV}_amd64.deb -> ${P}.deb"
+S=${WORKDIR}
 
 LICENSE="all-rights-reserved"
 SLOT="0"
@@ -59,8 +60,6 @@ BDEPEND="
 	dev-util/bbe
 	dev-util/patchelf
 "
-
-S=${WORKDIR}
 
 QA_PREBUILT="*"
 

--- a/media-gfx/zwcad/zwcad-2023.23.0.3.4-r2.ebuild
+++ b/media-gfx/zwcad/zwcad-2023.23.0.3.4-r2.ebuild
@@ -17,6 +17,7 @@ SRC_URI="
 	${URI_UNIONTECH}/${MY_PGK_NAME}/${MY_PGK_NAME}_${MY_PV}_amd64.deb -> ${P}.deb
 	${URI_ANACONDA}/python/3.7.13/download/linux-64/python-3.7.13-h12debd9_0.tar.bz2 -> ${PN}-python-3.7.13.tar.bz2
 "
+S=${WORKDIR}
 
 LICENSE="all-rights-reserved"
 SLOT="0"
@@ -36,8 +37,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 
 BDEPEND="dev-util/patchelf"
-
-S=${WORKDIR}
 
 QA_PREBUILT="*"
 

--- a/media-video/implay/implay-1.5.1.ebuild
+++ b/media-video/implay/implay-1.5.1.ebuild
@@ -9,6 +9,7 @@ inherit cmake desktop xdg-utils
 DESCRIPTION="A Cross-Platform Desktop Media Player"
 HOMEPAGE="https://tsl0922.github.io/ImPlay"
 SRC_URI="https://github.com/tsl0922/ImPlay/archive/refs/tags/${PV}.tar.gz ->  ImPlay-continuous.tar.gz"
+S="${WORKDIR}/ImPlay-${PV}"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
@@ -19,8 +20,6 @@ DEPEND="
 	media-video/mpv
 	x11-libs/gtk+
 "
-
-S="${WORKDIR}/ImPlay-${PV}"
 
 src_configure() {
 	CMAKE_BUILD_TYPE="Release"

--- a/net-libs/jzmq/jzmq-9999.ebuild
+++ b/net-libs/jzmq/jzmq-9999.ebuild
@@ -12,14 +12,13 @@ if [[ ${PV} == "9999" ]] ; then
 	vcs=git-r3
 fi
 
+S="${WORKDIR}/${P}/${PN}-jni"
 LICENSE="LGPL-3"
 SLOT="0"
 
 DEPEND="net-libs/zeromq
 	>=virtual/jre-1.7:*"
 RDEPEND="${DEPEND}"
-
-S="${WORKDIR}/${P}/${PN}-jni"
 
 src_prepare() {
 	default

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-1.3.ebuild
@@ -9,9 +9,9 @@ DESCRIPTION="PCMan is a gtk+ based free BBS client"
 HOMEPAGE="https://github.com/pcman-bbs/pcmanx"
 SRC_URI="https://github.com/pcman-bbs/pcmanx/releases/download/${PV}/${P}.tar.xz"
 
-KEYWORDS="~amd64"
-SLOT="0"
 LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64"
 IUSE="+libnotify +proxy iplookup +wget"
 
 COMMON_DEPEND="

--- a/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
+++ b/net-misc/pcmanx-gtk2/pcmanx-gtk2-9999.ebuild
@@ -10,8 +10,8 @@ HOMEPAGE="https://github.com/pcman-bbs/pcmanx"
 
 EGIT_REPO_URI="https://github.com/pcman-bbs/pcmanx.git"
 
-SLOT="0"
 LICENSE="GPL-2"
+SLOT="0"
 IUSE="+libnotify +proxy iplookup +wget"
 
 COMMON_DEPEND="

--- a/net-misc/remmina-plugin-rustdesk/remmina-plugin-rustdesk-1.0.0.0-r1.ebuild
+++ b/net-misc/remmina-plugin-rustdesk/remmina-plugin-rustdesk-1.0.0.0-r1.ebuild
@@ -14,6 +14,7 @@ SRC_URI="
 		-> remmina-plugin-builder-${_BUILDERVER}.tar.gz
 	https://github.com/muflone/remmina-plugin-rustdesk/archive/${PV}.tar.gz -> ${P}.tar.gz
 "
+S=${WORKDIR}/build
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
@@ -24,8 +25,6 @@ DEPEND="
 	x11-libs/gtk+:3
 "
 RDEPEND="${DEPEND}"
-
-S=${WORKDIR}/build
 
 src_unpack() {
 	default_src_unpack

--- a/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
+++ b/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
@@ -9,6 +9,7 @@ inherit meson python-any-r1 virtualx xdg
 DESCRIPTION="jonaburg's picom fork with dual_kawase blur and rounded corners"
 HOMEPAGE="https://github.com/jonaburg/picom"
 SRC_URI="https://github.com/jonaburg/picom/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/picom-${PV}"
 
 LICENSE="MPL-2.0 MIT"
 SLOT="0"
@@ -45,8 +46,6 @@ BDEPEND="virtual/pkgconfig
 "
 
 DOCS=( README.md picom.sample.conf )
-
-S="${WORKDIR}/picom-${PV}"
 
 src_configure() {
 	local emesonargs=(


### PR DESCRIPTION
Fix variable order (S should occur before RESTRICT) for 12 packages:

- app-emulation/deepin-wine-helper
- app-emulation/looking-glass
- dev-embedded/at32workbench
- dev-python/frozendict
- games-misc/oh-my-git-bin
- media-gfx/zw3d
- media-gfx/zwcad
- media-video/implay
- net-libs/jzmq
- net-misc/pcmanx-gtk2
- net-misc/remmina-plugin-rustdesk
- x11-misc/picom-jonaburg