### PR TITLE
Add new packages RSS workflow

### DIFF
--- a/.github/workflows/new-packages-rss.yml
+++ b/.github/workflows/new-packages-rss.yml
@@ -1,0 +1,68 @@
+name: New packages RSS
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+env:
+  GENERATOR_VERSION: v0.1.7
+  GENERATOR_BINARY: gentoo-overlay-new-packages-to-rss-linux-x86_64
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout overlay
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download RSS generator
+        run: |
+          base="https://github.com/vitaly-zdanevich/gentoo-overlay-new-packages-to-rss/releases/download/${GENERATOR_VERSION}"
+          curl -fsSLO "${base}/${GENERATOR_BINARY}"
+          curl -fsSLO "${base}/${GENERATOR_BINARY}.sha256"
+          sha256sum -c "${GENERATOR_BINARY}.sha256"
+          chmod +x "${GENERATOR_BINARY}"
+
+      - name: Generate RSS
+        run: |
+          ./${GENERATOR_BINARY} \
+            --repo . \
+            --repo-url "https://github.com/${{ github.repository }}" \
+            --self-url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/gentoo-zh.rss" \
+            --output "public/gentoo-zh.rss"
+          printf '%s\n' \
+            '<!doctype html>' \
+            '<meta charset="utf-8">' \
+            '<title>gentoo-zh new packages RSS</title>' \
+            '<a href="./gentoo-zh.rss">gentoo-zh.rss</a>' \
+            > public/index.html
+          touch public/.nojekyll
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: public
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ follow rule no.1 and no.2
 
 https://github.com/microcai/gentoo-zh/blob/deps-table/relation.md
 
+# new packages RSS
+
+Newly added packages are published as RSS:
+
+https://microcai.github.io/gentoo-zh/gentoo-zh.rss
+
+For reading RSS from the terminal, try [Newsboat](https://packages.gentoo.org/packages/net-news/newsboat), a CLI RSS/Atom reader:
+
+```
+emerge --ask net-news/newsboat
+```
+
 # commit message
 
 * for non-version bump commit, commit message should be like this:


### PR DESCRIPTION
Closes: https://github.com/microcai/gentoo-zh/issues/10222

It works on my fork: https://vitaly-zdanevich.github.io/gentoo-zh/gentoo-zh.rss

Screenshots from Newsbot:

<img width="571" height="251" alt="image" src="https://github.com/user-attachments/assets/bb071033-099e-4d66-ad3b-ba1be8686832" />

<img width="717" height="1180" alt="image" src="https://github.com/user-attachments/assets/62cf90f5-8d33-4838-a1c8-1f0838aed786" />

<img width="1004" height="479" alt="image" src="https://github.com/user-attachments/assets/ac87874c-339b-4b81-afaf-4054c20e9b6e" />

Maybe on a page we can have something similar to https://packages.gentoo.org/

<img width="1191" height="908" alt="image" src="https://github.com/user-attachments/assets/5919eef6-2568-4951-83c6-408a2e530b38" />
