### PR TITLE
Update repository metadata after rename to gentoo-zh/overlay

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   eix:
-    if: github.repository == 'Gentoo-zh/gentoo-zh'
+    if: github.repository == 'gentoo-zh/overlay'
     runs-on: ubuntu-latest
     container:
       image: gentoo/stage3
@@ -135,6 +135,6 @@ jobs:
         name: ${{ matrix.name }}
         newver: ${{ matrix.newver }}
         oldver: ${{ matrix.oldver }}
-        GITHUB_TOKEN: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }} # https://github.com/Gentoo-zh/gentoo-zh/pull/3130
+        GITHUB_TOKEN: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }} # https://github.com/gentoo-zh/overlay/pull/3130
       run: |
         go run . --file gentoo-zh/.github/workflows/overlay.toml --name "$name" --newver "$newver" --oldver "$oldver"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,43 @@
+# gentoo-zh repository migration / gentoo-zh 仓库迁移说明
+
+## 中文
+
+gentoo-zh overlay 已通过 GitHub repository transfer 从个人仓库迁移到社区组织仓库：
+
+- 原仓库：https://github.com/microcai/gentoo-zh
+- 当前仓库：https://github.com/gentoo-zh/overlay
+
+该仓库先从 microcai 个人账号 transfer 到 gentoo-zh 组织（当时为 `gentoo-zh/gentoo-zh`），随后经社区投票（21:9）定名并重命名为 `gentoo-zh/overlay`；`microcai/gentoo-zh` 和 `gentoo-zh/gentoo-zh` 两个旧地址都会一跳 301 直达新仓库（网页和 git 均可），现有用户不受影响。相关更新也已提交到 Gentoo 官方 overlay 登记（gentoo/api-gentoo-org#829）。
+
+迁移完成后，`gentoo-zh/overlay` 是 gentoo-zh overlay 的正式维护入口。
+
+过去所有维护者和用户对 gentoo-zh 的贡献会随仓库迁移一并保留。后续维护在 `gentoo-zh/overlay` 继续进行。
+
+为了让仓库地址与当前维护入口保持一致，建议在方便时将本地 remote 更新为：
+
+```bash
+git remote set-url origin https://github.com/gentoo-zh/overlay.git
+```
+
+后续 issue、pull request 和维护讨论请使用当前仓库。
+
+## English
+
+The gentoo-zh overlay has been transferred from the personal repository to the community organization through GitHub repository transfer:
+
+- Previous repository: https://github.com/microcai/gentoo-zh
+- Current repository: https://github.com/gentoo-zh/overlay
+
+The repository was first transferred from microcai's personal account to the gentoo-zh organization (then `gentoo-zh/gentoo-zh`), and later renamed to `gentoo-zh/overlay` following a community poll (21 vs 9); both `microcai/gentoo-zh` and `gentoo-zh/gentoo-zh` 301-redirect to the new repository in a single hop (web and git), so existing users are not affected. A corresponding update has been submitted to the Gentoo overlay registry (gentoo/api-gentoo-org#829).
+
+After the transfer, `gentoo-zh/overlay` is the main repository for the gentoo-zh overlay.
+
+Contributions from past maintainers and users are preserved as part of this repository transfer. Future maintenance continues at `gentoo-zh/overlay`.
+
+To keep local remotes aligned with the current maintenance location, update them when convenient:
+
+```bash
+git remote set-url origin https://github.com/gentoo-zh/overlay.git
+```
+
+Please use the current repository for future issues, pull requests, and maintenance discussions.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+> [!NOTE]
+> gentoo-zh overlay has moved to https://github.com/gentoo-zh/overlay. Old GitHub URLs continue to redirect. If you manually configured a remote, update it when convenient.
+
+## Repository migration
+
+This repository was transferred from `microcai/gentoo-zh` to the `gentoo-zh` organization through GitHub repository transfer, and later renamed to `gentoo-zh/overlay`.
+
+The current repository is:
+
+https://github.com/gentoo-zh/overlay
+
+See [MIGRATION.md](./MIGRATION.md) for details.
+
 # How to add this overlay to your Gentoo system
 
 ```
@@ -19,7 +32,7 @@ follow rule no.1 and no.2
 
 # the dependencies table
 
-https://github.com/Gentoo-zh/gentoo-zh/blob/deps-table/relation.md
+https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 
 # commit message
 

--- a/metadata/news/2026-07-05-repo-moved-to-overlay/2026-07-05-repo-moved-to-overlay.en.txt
+++ b/metadata/news/2026-07-05-repo-moved-to-overlay/2026-07-05-repo-moved-to-overlay.en.txt
@@ -1,0 +1,46 @@
+Title: gentoo-zh overlay moved to gentoo-zh/overlay
+Author: zakkaus <zakk@gentoozh.org>
+Content-Type: text/plain
+Posted: 2026-07-05
+Revision: 1
+News-Item-Format: 1.0
+
+The gentoo-zh overlay was transferred from the personal account:
+
+https://github.com/microcai/gentoo-zh
+
+to the gentoo-zh organization through GitHub repository transfer, and
+then renamed to its current location:
+
+https://github.com/gentoo-zh/overlay
+
+Both old addresses (microcai/gentoo-zh and gentoo-zh/gentoo-zh)
+301-redirect to the new repository in a single hop, for both the web and
+Git, so existing setups keep working. The gentoo-zh overlay is now
+maintained in the new repository.
+
+Please use the new repository for future issues, pull requests, and
+maintenance discussions.
+
+For more details, see MIGRATION.md in the repository.
+
+Users who configured the gentoo-zh overlay manually can update to the new
+address when convenient.
+
+Re-add the overlay:
+
+sudo eselect repository remove gentoo-zh
+sudo eselect repository add gentoo-zh git https://github.com/gentoo-zh/overlay.git
+sudo emaint sync -r gentoo-zh
+
+Or edit whichever file under /etc/portage/repos.conf/ contains the [gentoo-zh]
+section (eselect-repo.conf if you added it with eselect) and set its sync-uri to
+the new address:
+
+[gentoo-zh]
+location = /var/db/repos/gentoo-zh
+sync-type = git
+sync-uri = https://github.com/gentoo-zh/overlay.git
+auto-sync = yes
+
+Then run emerge --sync gentoo-zh.

--- a/metadata/news/2026-07-05-repo-moved-to-overlay/2026-07-05-repo-moved-to-overlay.zh.txt
+++ b/metadata/news/2026-07-05-repo-moved-to-overlay/2026-07-05-repo-moved-to-overlay.zh.txt
@@ -1,0 +1,41 @@
+Title: gentoo-zh overlay moved to gentoo-zh/overlay
+Author: zakkaus <zakk@gentoozh.org>
+Content-Type: text/plain
+Posted: 2026-07-05
+Revision: 1
+News-Item-Format: 1.0
+
+gentoo-zh overlay 已通过 GitHub repository transfer 从个人账号：
+
+https://github.com/microcai/gentoo-zh
+
+迁移到 gentoo-zh 组织，随后重命名为当前地址：
+
+https://github.com/gentoo-zh/overlay
+
+两个旧地址（microcai/gentoo-zh 和 gentoo-zh/gentoo-zh）都会一跳 301 直达新仓库
+（网页和 git 均可），现有配置不受影响。新仓库是 gentoo-zh overlay 后续维护的
+正式入口。
+
+后续 issue、pull request 和维护讨论请使用新仓库。
+
+更多细节请见仓库根目录的 MIGRATION.md。
+
+手动配置过 gentoo-zh overlay 的用户，建议在方便时更新到新地址。
+
+重新添加 overlay：
+
+sudo eselect repository remove gentoo-zh
+sudo eselect repository add gentoo-zh git https://github.com/gentoo-zh/overlay.git
+sudo emaint sync -r gentoo-zh
+
+或编辑 /etc/portage/repos.conf/ 下含 [gentoo-zh] 段的那个配置文件（用 eselect
+添加的在 eselect-repo.conf），把该段的 sync-uri 改成新地址：
+
+[gentoo-zh]
+location = /var/db/repos/gentoo-zh
+sync-type = git
+sync-uri = https://github.com/gentoo-zh/overlay.git
+auto-sync = yes
+
+然后 emerge --sync gentoo-zh。

--- a/repo.xml
+++ b/repo.xml
@@ -4,11 +4,11 @@
   <repo quality="experimental" status="unofficial">
     <name>gentoo-zh</name>
     <description>merged overlay of Gentoo-{China,Taiwan}</description>
-    <homepage>http://gentoo-zh.googlecode.com/</homepage>
+    <homepage>https://gentoozh.org</homepage>
     <owner type="project">
-      <email>microcaicai@gmail.com, robert.zhangle@gmail.com</email>
+      <email>overlay@gentoozh.org</email>
       <name>gentoo-zh</name>
     </owner>
-    <source type="git">https://github.com/Gentoo-zh/gentoo-zh.git</source>
+    <source type="git">https://github.com/gentoo-zh/overlay.git</source>
   </repo>
 </repositories>

--- a/sys-kernel/cachyos-sources/cachyos-sources-6.18.6.ebuild
+++ b/sys-kernel/cachyos-sources/cachyos-sources-6.18.6.ebuild
@@ -52,7 +52,7 @@ src_prepare() {
 pkg_setup() {
 	ewarn
 	ewarn "${PN} is *not* supported by the Gentoo Kernel Project in any way."
-	ewarn "If you need support, please contact https://github.com/microcai/gentoo-zh and ${HOMEPAGE} directly."
+	ewarn "If you need support, please contact https://github.com/gentoo-zh/overlay and ${HOMEPAGE} directly."
 	ewarn "Do *not* open bugs in Gentoo's bugzilla unless you have issues with"
 	ewarn "the ebuilds. Thank you."
 	ewarn


### PR DESCRIPTION
Renamed to gentoo-zh/overlay (after moving to the org): update the in-repo
URLs and metadata to match, and add MIGRATION.md + a news item so people can
repoint sync-uri. Old URLs 301-redirect.