### PR TITLE
readme: use "we" instead of "I"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It is recommended to run `pkgdev commit` to quickly generate commit messages.
 
 # Contributions
 
-* I trust contributors that have commit rights, therefore commitors
+* We trust contributors that have commit rights, therefore commitors
   should think carefully before committing.
 
 * Generative AI may be used to assist ebuild maintenance, but contributors must

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,7 +54,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 
 # 贡献
 
-* 我信任拥有提交权限的贡献者，因此提交者在提交前应谨慎确认。
+* 我们信任拥有提交权限的贡献者，因此提交者在提交前应谨慎确认。
 
 * 可以使用生成式 AI 辅助 ebuild 维护，但贡献者必须确保相关 ebuild
   修改的质量。尤其要在修改后验证功能正确性；包括 CLI、GUI 等应用形态在内的应用，

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -54,7 +54,7 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 
 # 貢獻
 
-* 我信任擁有提交權限的貢獻者，因此提交者在提交前應謹慎確認。
+* 我們信任擁有提交權限的貢獻者，因此提交者在提交前應謹慎確認。
 
 * 可以使用生成式 AI 輔助 ebuild 維護，但貢獻者必須確保相關 ebuild
   修改的品質。尤其要在修改後驗證功能正確性；包括 CLI、GUI 等應用型態在內的應用，


### PR DESCRIPTION
readme: use "we" instead of "I" now that gentoo-zh is an organization