### PR TITLE
x11-terms/termius: fix fatal startup crash from non-exec crashpad handler

### DIFF
--- a/x11-terms/termius/termius-9.40.1-r1.ebuild
+++ b/x11-terms/termius/termius-9.40.1-r1.ebuild
@@ -63,6 +63,9 @@ src_install() {
 	exeinto /opt/termius
 	doexe opt/Termius/termius-app
 	doexe opt/Termius/chrome-sandbox
+	# chrome_crashpad_handler is posix_spawn()'d by Chromium; without the
+	# executable bit it fails with EACCES and the app dies on startup.
+	doexe opt/Termius/chrome_crashpad_handler
 
 	fperms 4755 /opt/termius/chrome-sandbox
 


### PR DESCRIPTION
Termius 一啟動就崩潰,跳出「termius-app has encountered a fatal error and was closed」。

 journal:   termius[...]: [FATAL:spawn_subprocess.cc(221)] posix_spawn: Permission denied (13)

原因:ebuild 用 doins -r(權限 0644)安裝整包,只有 termius-app 和 chrome-sandbox 補回執行權限。但 chrome_crashpad_handler 是 Chromium
啟動時用 posix_spawn() 執行的獨立程式,少了執行權限就會回 EACCES (13)

CC: @Linerre (recent termius maintainer)


<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
