### PR TITLE
media-plugins/kotonoha: add 9999

### DIFF
--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -17,7 +17,6 @@ LICENSE="ISC LGPL-2.1+ MIT"
 SLOT="0"
 
 DEPEND="
-	${PYTHON_DEPS}
 	dev-libs/wayland
 	dev-qt/qtbase:6=[gui,wayland,widgets]
 	kde-plasma/layer-shell-qt:6
@@ -31,7 +30,7 @@ RDEPEND="
 	dev-qt/qtwayland:6
 	dev-qt/qtsvg:6
 "
-BDEPEND="${BDEPEND}
+BDEPEND="
 	dev-util/wayland-scanner
 	virtual/pkgconfig
 "

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -7,31 +7,34 @@ DISTUTILS_USE_PEP517=scikit-build-core
 DISTUTILS_EXT=1
 PYTHON_COMPAT=( python3_{13..14} )
 
-inherit cmake desktop distutils-r1 git-r3
+inherit desktop distutils-r1 git-r3 xdg
 
 DESCRIPTION="Wayland lyrics overlay for MPRIS-compatible media players"
 HOMEPAGE="https://github.com/locez/kotonoha"
 EGIT_REPO_URI="https://github.com/locez/kotonoha.git"
-EGIT_SUBMODULES=( '*' )
 
-LICENSE="MIT"
+LICENSE="ISC LGPL-2.1+ MIT"
 SLOT="0"
 
 DEPEND="
+	${PYTHON_DEPS}
 	dev-libs/wayland
-	dev-qt/qtbase:6
-	kde-plasma/layer-shell-qt
+	dev-qt/qtbase:6=[gui,wayland,widgets]
+	kde-plasma/layer-shell-qt:6
 "
 RDEPEND="
 	${DEPEND}
 	dev-python/aiohttp[${PYTHON_USEDEP}]
 	dev-python/dbus-fast[${PYTHON_USEDEP}]
-	dev-python/pyqt6[svg,${PYTHON_USEDEP}]
+	dev-python/pyqt6[gui,svg,widgets,${PYTHON_USEDEP}]
 	dev-python/qasync[${PYTHON_USEDEP}]
 	dev-qt/qtwayland:6
 	dev-qt/qtsvg:6
 "
-BDEPEND="virtual/pkgconfig"
+BDEPEND="${BDEPEND}
+	dev-util/wayland-scanner
+	virtual/pkgconfig
+"
 
 EPYTEST_PLUGINS=( pytest-asyncio )
 distutils_enable_tests pytest
@@ -39,11 +42,16 @@ distutils_enable_tests pytest
 python_configure_all() {
 	DISTUTILS_ARGS=(
 		-DKOTONOHA_INSTALL_DIR=kotonoha
+		-DKOTONOHA_INSTALL_LICENSE=OFF
 	)
 }
 
 python_install_all() {
 	distutils-r1_python_install_all
+	dolicense LICENSE
 	domenu packaging/kotonoha.desktop
 	newicon src/kotonoha/assets/icon.png kotonoha.png
+	doman packaging/kotonoha.1
+	insinto /usr/share/metainfo
+	doins packaging/dev.locez.kotonoha.metainfo.xml
 }

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -47,7 +47,6 @@ python_configure_all() {
 
 python_install_all() {
 	distutils-r1_python_install_all
-	dodoc LICENSE
 	domenu packaging/kotonoha.desktop
 	newicon src/kotonoha/assets/icon.png kotonoha.png
 	doman packaging/kotonoha.1

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -47,7 +47,7 @@ python_configure_all() {
 
 python_install_all() {
 	distutils-r1_python_install_all
-	dolicense LICENSE
+	dodoc LICENSE
 	domenu packaging/kotonoha.desktop
 	newicon src/kotonoha/assets/icon.png kotonoha.png
 	doman packaging/kotonoha.1

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -1,0 +1,51 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=hatchling
+DISTUTILS_EXT=1
+PYTHON_COMPAT=( python3_{13..14} )
+
+inherit desktop distutils-r1 git-r3
+
+DESCRIPTION="Wayland lyrics overlay for MPRIS-compatible media players"
+HOMEPAGE="https://github.com/locez/kotonoha"
+EGIT_REPO_URI="https://github.com/locez/kotonoha.git"
+EGIT_SUBMODULES=( '*' )
+
+LICENSE="MIT"
+SLOT="0"
+
+RDEPEND="
+	dev-python/aiohttp[${PYTHON_USEDEP}]
+	dev-python/dbus-fast[${PYTHON_USEDEP}]
+	dev-python/pyqt6[svg,${PYTHON_USEDEP}]
+	dev-python/qasync[${PYTHON_USEDEP}]
+	dev-qt/qtbase:6
+	dev-qt/qtwayland:6
+	kde-plasma/layer-shell-qt
+"
+
+EPYTEST_PLUGINS=( pytest-asyncio )
+distutils_enable_tests pytest
+
+python_prepare_all() {
+	sed -i \
+		-e '/hatch-build-scripts/d' \
+		-e '/\[tool.hatch.build.hooks.build-scripts\]/,/artifacts =/d' \
+		pyproject.toml || die
+
+	distutils-r1_python_prepare_all
+}
+
+src_compile() {
+	./src/kotonoha/build_bridge.sh || die
+	distutils-r1_src_compile
+}
+
+python_install_all() {
+	distutils-r1_python_install_all
+	domenu packaging/kotonoha.desktop
+	newicon src/kotonoha/assets/icon.png kotonoha.png
+}

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=hatchling
+DISTUTILS_USE_PEP517=scikit-build-core
 DISTUTILS_EXT=1
 PYTHON_COMPAT=( python3_{13..14} )
 
@@ -36,41 +36,10 @@ BDEPEND="virtual/pkgconfig"
 EPYTEST_PLUGINS=( pytest-asyncio )
 distutils_enable_tests pytest
 
-python_prepare_all() {
-	sed -i \
-		-e '/hatch-build-scripts/d' \
-		-e '/\[tool.hatch.build.hooks.build-scripts\]/,/artifacts =/d' \
-		pyproject.toml || die
-
-	distutils-r1_python_prepare_all
-}
-
-src_prepare() {
-	cmake_src_prepare
-	distutils-r1_src_prepare
-}
-
-src_configure() {
-	python_setup
-
-	local mycmakeargs=(
-		-DPython3_EXECUTABLE="${PYTHON}"
-		-DKOTONOHA_INSTALL_DIR=src/kotonoha
+python_configure_all() {
+	DISTUTILS_ARGS=(
+		-DKOTONOHA_INSTALL_DIR=kotonoha
 	)
-
-	cmake_src_configure
-	distutils-r1_src_configure
-}
-
-src_compile() {
-	cmake_src_compile
-	cmake --install "${BUILD_DIR}" \
-		--config "${CMAKE_BUILD_TYPE}" \
-		--prefix "${S}" \
-		--component KotonohaBridge \
-		|| die
-
-	distutils-r1_src_compile
 }
 
 python_install_all() {

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -29,6 +29,7 @@ RDEPEND="
 	dev-python/pyqt6[svg,${PYTHON_USEDEP}]
 	dev-python/qasync[${PYTHON_USEDEP}]
 	dev-qt/qtwayland:6
+	dev-qt/qtsvg:6
 "
 BDEPEND="virtual/pkgconfig"
 

--- a/media-plugins/kotonoha/kotonoha-9999.ebuild
+++ b/media-plugins/kotonoha/kotonoha-9999.ebuild
@@ -7,7 +7,7 @@ DISTUTILS_USE_PEP517=hatchling
 DISTUTILS_EXT=1
 PYTHON_COMPAT=( python3_{13..14} )
 
-inherit desktop distutils-r1 git-r3
+inherit cmake desktop distutils-r1 git-r3
 
 DESCRIPTION="Wayland lyrics overlay for MPRIS-compatible media players"
 HOMEPAGE="https://github.com/locez/kotonoha"
@@ -17,15 +17,20 @@ EGIT_SUBMODULES=( '*' )
 LICENSE="MIT"
 SLOT="0"
 
+DEPEND="
+	dev-libs/wayland
+	dev-qt/qtbase:6
+	kde-plasma/layer-shell-qt
+"
 RDEPEND="
+	${DEPEND}
 	dev-python/aiohttp[${PYTHON_USEDEP}]
 	dev-python/dbus-fast[${PYTHON_USEDEP}]
 	dev-python/pyqt6[svg,${PYTHON_USEDEP}]
 	dev-python/qasync[${PYTHON_USEDEP}]
-	dev-qt/qtbase:6
 	dev-qt/qtwayland:6
-	kde-plasma/layer-shell-qt
 "
+BDEPEND="virtual/pkgconfig"
 
 EPYTEST_PLUGINS=( pytest-asyncio )
 distutils_enable_tests pytest
@@ -39,8 +44,31 @@ python_prepare_all() {
 	distutils-r1_python_prepare_all
 }
 
+src_prepare() {
+	cmake_src_prepare
+	distutils-r1_src_prepare
+}
+
+src_configure() {
+	python_setup
+
+	local mycmakeargs=(
+		-DPython3_EXECUTABLE="${PYTHON}"
+		-DKOTONOHA_INSTALL_DIR=src/kotonoha
+	)
+
+	cmake_src_configure
+	distutils-r1_src_configure
+}
+
 src_compile() {
-	./src/kotonoha/build_bridge.sh || die
+	cmake_src_compile
+	cmake --install "${BUILD_DIR}" \
+		--config "${CMAKE_BUILD_TYPE}" \
+		--prefix "${S}" \
+		--component KotonohaBridge \
+		|| die
+
 	distutils-r1_src_compile
 }
 

--- a/media-plugins/kotonoha/metadata.xml
+++ b/media-plugins/kotonoha/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>locez@locez.com</email>
+		<name>Locez</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">locez/kotonoha</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
## Summary

- add a live ebuild for the Kotonoha Wayland lyrics overlay
- use upstream's `scikit-build-core` backend for the CMake bridge wheel
- pass the wheel install directory through `distutils-r1` while retaining `cmake.eclass` toolchain dependencies
- install the desktop entry and icon with the required Python, Qt, Wayland, and LayerShellQt dependencies

## Testing

- full `ebuild clean configure compile install` on amd64 with `python3_14`
- inspected the wheel and install image: one `kotonoha/libkoto-layer.so` at the expected site-packages path, no RPATH/RUNPATH, and dynamic links to system Qt6, LayerShellQt, and Wayland libraries
- `pkgcheck scan --net media-plugins/kotonoha`
- `pkgcheck scan --commits upstream/master --net`
- `pkgcheck scan --commits --net` (no Kotonoha findings; unrelated findings came from commits already on canonical master)

`ebuild test` and an interactive GUI smoke test were not run. The live ebuild intentionally has no `KEYWORDS`, and no `Manifest` is needed because it has no distfiles.

---

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
