### PR TITLE
.github/workflows: add mirror to codeberg

### DIFF
--- a/.github/workflows/mirror-to-codeberg.yml
+++ b/.github/workflows/mirror-to-codeberg.yml
@@ -1,0 +1,31 @@
+name: mirror to codeberg
+on:
+  workflow_dispatch:
+  push:
+  delete:
+  schedule:
+    - cron: '40 4 * * *'
+
+concurrency:
+  group: mirror-to-codeberg
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    if: github.repository == 'gentoo-zh/overlay'
+    steps:
+    - name: Clone GitHub repository (bare mirror)
+      run: git clone --mirror "https://github.com/${GITHUB_REPOSITORY}.git" repo.git
+
+    - name: Push branches and tags to Codeberg
+      working-directory: repo.git
+      env:
+        SSH_KEY: ${{ secrets.CODEBERG_SSH_KEY }}
+      run: |
+        mkdir -p ~/.ssh
+        printf '%s\n' "$SSH_KEY" > ~/.ssh/codeberg_mirror
+        chmod 600 ~/.ssh/codeberg_mirror
+        ssh-keyscan codeberg.org >> ~/.ssh/known_hosts 2>/dev/null
+        export GIT_SSH_COMMAND="ssh -i ~/.ssh/codeberg_mirror"
+        git push --prune git@codeberg.org:gentoo-zh/overlay.git \
+          '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'


### PR DESCRIPTION
每次 push 自動把所有 branches/tags 同步到 https://codeberg.org/gentoo-zh/overlay ，另外每天 04:40 UTC 定時同步一次兜底。

Codeberg 端的 deploy key（寫入權限）和 GitHub 端的 `CODEBERG_SSH_KEY` secret 都已設定好。同步是強制覆蓋（`--prune` + force push），Codeberg 那份是唯讀鏡像，不要直接往那邊推。