### PR TITLE
*/*: remove trailing full stop from DESCRIPTION

### DIFF
--- a/app-admin/chezmoi-bin/chezmoi-bin-2.70.0.ebuild
+++ b/app-admin/chezmoi-bin/chezmoi-bin-2.70.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit unpacker shell-completion
 
-DESCRIPTION="Manage your dotfiles across multiple diverse machines, securely."
+DESCRIPTION="Manage your dotfiles across multiple diverse machines, securely"
 HOMEPAGE="https://www.chezmoi.io https://github.com/twpayne/chezmoi"
 
 SRC_URI="

--- a/app-admin/chezmoi/chezmoi-2.70.0.ebuild
+++ b/app-admin/chezmoi/chezmoi-2.70.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit go-module shell-completion
 
-DESCRIPTION="Manage your dotfiles across multiple diverse machines, securely."
+DESCRIPTION="Manage your dotfiles across multiple diverse machines, securely"
 HOMEPAGE="https://www.chezmoi.io https://github.com/twpayne/chezmoi"
 SRC_URI="https://github.com/twpayne/chezmoi/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 SRC_URI+=" https://github.com/gentoo-zh-drafts/chezmoi/releases/download/v${PV}/${P}-vendor.tar.xz"

--- a/app-admin/enpass/enpass-6.10.1.1661.ebuild
+++ b/app-admin/enpass/enpass-6.10.1.1661.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="A cross-platform, complete password management solution."
+DESCRIPTION="A cross-platform, complete password management solution"
 HOMEPAGE="https://www.enpass.io"
 SRC_URI="https://apt.enpass.io/pool/main/e/${PN}/${PN}_${PV}_amd64.deb"
 

--- a/app-admin/enpass/enpass-6.11.13.1957.ebuild
+++ b/app-admin/enpass/enpass-6.11.13.1957.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="A cross-platform, complete password management solution."
+DESCRIPTION="A cross-platform, complete password management solution"
 HOMEPAGE="https://www.enpass.io"
 SRC_URI="https://apt.enpass.io/pool/main/e/${PN}/${PN}_${PV}_amd64.deb"
 

--- a/app-admin/enpass/enpass-6.11.6.1833.ebuild
+++ b/app-admin/enpass/enpass-6.11.6.1833.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="A cross-platform, complete password management solution."
+DESCRIPTION="A cross-platform, complete password management solution"
 HOMEPAGE="https://www.enpass.io"
 SRC_URI="https://apt.enpass.io/pool/main/e/${PN}/${PN}_${PV}_amd64.deb"
 

--- a/app-editors/marktext-bin/marktext-bin-0.19.1.ebuild
+++ b/app-editors/marktext-bin/marktext-bin-0.19.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop xdg unpacker
 
-DESCRIPTION="A simple and elegant markdown editor, available for Linux, macOS and Windows."
+DESCRIPTION="A simple and elegant markdown editor, available for Linux, macOS and Windows"
 HOMEPAGE="https://github.com/marktext/marktext"
 SRC_URI="https://github.com/marktext/marktext/releases/download/v${PV}/${PN%-bin}-linux-${PV}.deb -> ${P}.deb"
 

--- a/app-editors/typora/typora-0.11.18.ebuild
+++ b/app-editors/typora/typora-0.11.18.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="Typora will give you a seamless experience as both a reader and a writer."
+DESCRIPTION="Typora will give you a seamless experience as both a reader and a writer"
 HOMEPAGE="https://typora.io"
 SRC_URI="https://web.archive.org/web/20211127121316if_/https://typora.io/linux/typora_${PV}_amd64.deb"
 

--- a/app-editors/typora/typora-1.13.6.ebuild
+++ b/app-editors/typora/typora-1.13.6.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit unpacker xdg
 
-DESCRIPTION="A truely minimal markdown editor."
+DESCRIPTION="A truely minimal markdown editor"
 HOMEPAGE="https://typora.io"
 SRC_URI="https://download.typora.io/linux/typora_${PV}_amd64.deb"
 S="${WORKDIR}"

--- a/app-editors/windsurf/windsurf-1.9.2.ebuild
+++ b/app-editors/windsurf/windsurf-1.9.2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop shell-completion unpacker xdg
 
-DESCRIPTION="AI-powered code editor maintaining flow state with instant assistance."
+DESCRIPTION="AI-powered code editor maintaining flow state with instant assistance"
 HOMEPAGE="https://codeium.com"
 
 SRC_URI="https://windsurf-stable.codeiumdata.com/wVxQEIWkwPUEAGf3/apt/pool/main/w/windsurf/Windsurf-linux-x64-${PV}.deb"

--- a/app-i18n/dvp/dvp-1.2.1-r1.ebuild
+++ b/app-i18n/dvp/dvp-1.2.1-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 MY_PV=${PV//./_}
 MY_P="${PN}-${MY_PV}"
 
-DESCRIPTION="The kbd keymap for Programmer Dvorak."
+DESCRIPTION="The kbd keymap for Programmer Dvorak"
 HOMEPAGE="http://kaufmann.no/roland/dvorak/index.html"
 SRC_URI="http://kaufmann.no/downloads/linux/${MY_P}.map.gz"
 

--- a/app-i18n/fcitx-chewing/fcitx-chewing-9999.ebuild
+++ b/app-i18n/fcitx-chewing/fcitx-chewing-9999.ebuild
@@ -7,7 +7,7 @@ MY_PN="fcitx5-chewing"
 
 inherit cmake git-r3 xdg
 
-DESCRIPTION="Chewing Wrapper for Fcitx."
+DESCRIPTION="Chewing Wrapper for Fcitx"
 HOMEPAGE="https://github.com/fcitx/fcitx5-chewing"
 EGIT_REPO_URI="https://github.com/fcitx/fcitx5-chewing.git"
 

--- a/app-misc/mdx_util/mdx_util-20251029.ebuild
+++ b/app-misc/mdx_util/mdx_util-20251029.ebuild
@@ -8,7 +8,7 @@ CRATES="
 
 inherit cargo
 
-DESCRIPTION="A command line tools for handling mdx related jobs."
+DESCRIPTION="A command line tools for handling mdx related jobs"
 HOMEPAGE="https://github.com/raymanzhang/mdx_util"
 SRC_URI="
 	https://github.com/raymanzhang/mdx_util/archive/068d57bd013ca343ca332c42fada96ee0453e391.tar.gz -> ${P}.tar.gz

--- a/app-misc/yazi/yazi-26.5.6.ebuild
+++ b/app-misc/yazi/yazi-26.5.6.ebuild
@@ -12,7 +12,7 @@ RUST_MIN_VER="1.95.0"
 
 inherit cargo desktop shell-completion xdg
 
-DESCRIPTION="Blazing fast terminal file manager written in Rust, based on async I/O."
+DESCRIPTION="Blazing fast terminal file manager written in Rust, based on async I/O"
 HOMEPAGE="https://yazi-rs.github.io"
 SRC_URI="
 	https://github.com/sxyazi/yazi/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz

--- a/app-office/freeoffice/freeoffice-1062.ebuild
+++ b/app-office/freeoffice/freeoffice-1062.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop pax-utils xdg
 
-DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite."
+DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite"
 HOMEPAGE="https://www.freeoffice.com"
 BASE_URI="https://www.softmaker.net/down/softmaker-freeoffice-2021-${PV}"
 SRC_URI="${BASE_URI}-amd64.tgz"

--- a/app-office/freeoffice/freeoffice-1064.ebuild
+++ b/app-office/freeoffice/freeoffice-1064.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop pax-utils xdg
 
-DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite."
+DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite"
 HOMEPAGE="https://www.freeoffice.com"
 BASE_URI="https://www.softmaker.net/down/softmaker-freeoffice-2021-${PV}"
 SRC_URI="${BASE_URI}-amd64.tgz"

--- a/app-office/freeoffice/freeoffice-1068.ebuild
+++ b/app-office/freeoffice/freeoffice-1068.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop pax-utils xdg
 
-DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite."
+DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite"
 HOMEPAGE="https://www.freeoffice.com"
 BASE_URI="https://www.softmaker.net/down/softmaker-freeoffice-2021-${PV}"
 SRC_URI="${BASE_URI}-amd64.tgz"

--- a/app-office/freeoffice/freeoffice-1220.ebuild
+++ b/app-office/freeoffice/freeoffice-1220.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop pax-utils xdg
 
-DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite."
+DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite"
 HOMEPAGE="https://www.freeoffice.com"
 BASE_URI="https://www.softmaker.net/down/softmaker-freeoffice-2024-${PV}"
 SRC_URI="${BASE_URI}-amd64.tgz"

--- a/app-office/freeoffice/freeoffice-1234.ebuild
+++ b/app-office/freeoffice/freeoffice-1234.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop pax-utils xdg
 
-DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite."
+DESCRIPTION="A complete, free Microsoft Office-compatible alternative office suite"
 HOMEPAGE="https://www.freeoffice.com/de/"
 BASE_URI="https://www.softmaker.net/down/softmaker-freeoffice-2024-${PV}"
 SRC_URI="${BASE_URI}-amd64.tgz"

--- a/app-pda/ipadcharge/ipadcharge-9999.ebuild
+++ b/app-pda/ipadcharge/ipadcharge-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 inherit git-r3
 
-DESCRIPTION="Enables USB charging for Apple devices."
+DESCRIPTION="Enables USB charging for Apple devices"
 HOMEPAGE="https://github.com/mkorenkov/ipad_charge"
 EGIT_REPO_URI="https://github.com/mkorenkov/ipad_charge.git"
 

--- a/app-vim/powerline/powerline-9999.ebuild
+++ b/app-vim/powerline/powerline-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 #VIM_PLUGIN_VIM_VERSION="7.0"
 inherit git-r3 vim-plugin
 
-DESCRIPTION="vim plugin: The ultimate vim statusline utility."
+DESCRIPTION="vim plugin: The ultimate vim statusline utility"
 HOMEPAGE="http://www.vim.org/scripts/script.php?script_id=3881"
 EGIT_REPO_URI="https://github.com/Lokaltog/vim-powerline.git"
 EGIT_BRANCH=develop

--- a/dev-java/google-java-format/google-java-format-1.35.0.ebuild
+++ b/dev-java/google-java-format/google-java-format-1.35.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DESCRIPTION="Reformats Java source code to comply with Google Java Style."
+DESCRIPTION="Reformats Java source code to comply with Google Java Style"
 HOMEPAGE="https://github.com/google/google-java-format"
 SRC_URI="https://github.com/google/google-java-format/releases/download/v${PV}/${P}-all-deps.jar"
 S="${WORKDIR}"

--- a/dev-libs/qnodeeditor/qnodeeditor-2.1.7_p20210113.ebuild
+++ b/dev-libs/qnodeeditor/qnodeeditor-2.1.7_p20210113.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit cmake
 
-DESCRIPTION="A general-purpose Qt-based library aimed at graph-controlled data processing."
+DESCRIPTION="A general-purpose Qt-based library aimed at graph-controlled data processing"
 HOMEPAGE="https://github.com/Qv2ray/QNodeEditor"
 GIT_COMMIT="808a7cf0359771a474db17a82cbf631746d8735d"
 SRC_URI="https://github.com/Qv2ray/QNodeEditor/archive/${GIT_COMMIT}.tar.gz -> ${P}.tar.gz"

--- a/dev-libs/v2ray-domain-list-community-bin/v2ray-domain-list-community-bin-20260710034646.ebuild
+++ b/dev-libs/v2ray-domain-list-community-bin/v2ray-domain-list-community-bin-20260710034646.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DESCRIPTION="Community managed domain list for V2Ray."
+DESCRIPTION="Community managed domain list for V2Ray"
 HOMEPAGE="https://github.com/v2fly/domain-list-community"
 SRC_URI="https://github.com/v2fly/domain-list-community/releases/download/${PV}/dlc.dat.xz -> ${P}.dat.xz"
 

--- a/dev-libs/v2ray-domain-list-community/v2ray-domain-list-community-20260710034646.ebuild
+++ b/dev-libs/v2ray-domain-list-community/v2ray-domain-list-community-20260710034646.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit go-module
 
-DESCRIPTION="Community managed domain list for V2Ray."
+DESCRIPTION="Community managed domain list for V2Ray"
 HOMEPAGE="https://github.com/v2fly/domain-list-community"
 SRC_URI="
 	https://github.com/v2fly/domain-list-community/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz

--- a/dev-libs/v2ray-geoip-bin/v2ray-geoip-bin-202607050337.ebuild
+++ b/dev-libs/v2ray-geoip-bin/v2ray-geoip-bin-202607050337.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DESCRIPTION="GeoIP for V2Ray."
+DESCRIPTION="GeoIP for V2Ray"
 HOMEPAGE="https://github.com/v2fly/geoip"
 SRC_URI="https://github.com/v2fly/geoip/releases/download/${PV}/geoip.dat -> ${P}.dat"
 

--- a/dev-libs/v2ray-geoip/v2ray-geoip-202607050337.ebuild
+++ b/dev-libs/v2ray-geoip/v2ray-geoip-202607050337.ebuild
@@ -7,7 +7,7 @@ inherit go-module
 
 DBIP_V="${PV:0:4}-${PV:4:2}"
 
-DESCRIPTION="GeoIP for V2Ray."
+DESCRIPTION="GeoIP for V2Ray"
 HOMEPAGE="https://github.com/v2fly/geoip"
 SRC_URI="
 	https://github.com/v2fly/geoip/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz

--- a/dev-libs/v2ray-rules-dat-bin/v2ray-rules-dat-bin-202607092306.ebuild
+++ b/dev-libs/v2ray-rules-dat-bin/v2ray-rules-dat-bin-202607092306.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DESCRIPTION="Enhanced edition of V2Ray rules dat files."
+DESCRIPTION="Enhanced edition of V2Ray rules dat files"
 HOMEPAGE="https://github.com/Loyalsoldier/v2ray-rules-dat"
 SRC_URI="
 	geosite? ( https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${PV}/geosite.dat -> ${P}-geosite.dat )

--- a/dev-util/redpanda-cpp/redpanda-cpp-3.4.ebuild
+++ b/dev-util/redpanda-cpp/redpanda-cpp-3.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 inherit xdg qmake-utils
-DESCRIPTION="A lightweight yet powerful C/C++/GNU Assembly IDE."
+DESCRIPTION="A lightweight yet powerful C/C++/GNU Assembly IDE"
 HOMEPAGE="http://royqh.net/redpandacpp/"
 SRC_URI="https://github.com/royqh1979/RedPanda-CPP/archive/refs/tags/v${PV}.tar.gz -> redpanda-cpp-${PV}.tar.gz"
 S="${WORKDIR}/RedPanda-CPP-${PV}"

--- a/dev-util/vcpkg-tool/vcpkg-tool-2025.12.16.ebuild
+++ b/dev-util/vcpkg-tool/vcpkg-tool-2025.12.16.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit cmake
 
-DESCRIPTION="Library manager for C/C++ (tool only)."
+DESCRIPTION="Library manager for C/C++ (tool only)"
 HOMEPAGE="https://github.com/microsoft/vcpkg-tool https://vcpkg.io/en/index.html"
 format-date() {
 	local input="$1"

--- a/dev-vcs/sourcegit-bin/sourcegit-bin-2026.07.ebuild
+++ b/dev-vcs/sourcegit-bin/sourcegit-bin-2026.07.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="Opensource Git GUI client."
+DESCRIPTION="Opensource Git GUI client"
 HOMEPAGE="https://github.com/sourcegit-scm/sourcegit"
 SRC_URI="https://github.com/sourcegit-scm/sourcegit/releases/download/v${PV}/sourcegit_${PV}-1_amd64.deb"
 

--- a/dev-vcs/sourcegit-bin/sourcegit-bin-2026.09.ebuild
+++ b/dev-vcs/sourcegit-bin/sourcegit-bin-2026.09.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="Opensource Git GUI client."
+DESCRIPTION="Opensource Git GUI client"
 HOMEPAGE="https://github.com/sourcegit-scm/sourcegit"
 SRC_URI="https://github.com/sourcegit-scm/sourcegit/releases/download/v${PV}/sourcegit_${PV}-1_amd64.deb"
 

--- a/dev-vcs/sourcegit-bin/sourcegit-bin-2026.15.ebuild
+++ b/dev-vcs/sourcegit-bin/sourcegit-bin-2026.15.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="Opensource Git GUI client."
+DESCRIPTION="Opensource Git GUI client"
 HOMEPAGE="https://github.com/sourcegit-scm/sourcegit"
 SRC_URI="https://github.com/sourcegit-scm/sourcegit/releases/download/v${PV}/sourcegit_${PV}-1_amd64.deb"
 

--- a/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-3.1.ebuild
+++ b/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-3.1.ebuild
@@ -13,7 +13,7 @@ else
 	KEYWORDS="~amd64"
 fi
 
-DESCRIPTION="Plasma 5 widget that displays the currently used network bandwidth."
+DESCRIPTION="Plasma 5 widget that displays the currently used network bandwidth"
 HOMEPAGE="https://www.kde-look.org/p/998895/
 https://github.com/dfaust/plasma-applet-netspeed-widget"
 

--- a/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-9999.ebuild
+++ b/kde-misc/plasma-applet-netspeed-widget/plasma-applet-netspeed-widget-9999.ebuild
@@ -13,7 +13,7 @@ else
 	KEYWORDS="~amd64"
 fi
 
-DESCRIPTION="Plasma 5 widget that displays the currently used network bandwidth."
+DESCRIPTION="Plasma 5 widget that displays the currently used network bandwidth"
 HOMEPAGE="https://www.kde-look.org/p/998895/
 https://github.com/dfaust/plasma-applet-netspeed-widget"
 

--- a/media-fonts/iansui/iansui-1.020.ebuild
+++ b/media-fonts/iansui/iansui-1.020.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 inherit font
 
-DESCRIPTION="An open-source Chinese font derived from Klee One (Fontworks)."
+DESCRIPTION="An open-source Chinese font derived from Klee One (Fontworks)"
 HOMEPAGE="https://github.com/ButTaiwan/iansui"
 SRC_URI="https://github.com/ButTaiwan/iansui/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
 

--- a/media-fonts/smiley-sans/smiley-sans-2.0.1.ebuild
+++ b/media-fonts/smiley-sans/smiley-sans-2.0.1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit font
 
 MY_PN="SmileySans"
-DESCRIPTION="An open-source font for Chinese."
+DESCRIPTION="An open-source font for Chinese"
 HOMEPAGE="https://github.com/atelier-anchor/smiley-sans"
 SRC_URI="https://github.com/atelier-anchor/smiley-sans/releases/download/v${PV}/smiley-sans-v${PV}.zip -> ${P}.zip"
 S=${WORKDIR}

--- a/media-fonts/tiejili/tiejili-1.100.ebuild
+++ b/media-fonts/tiejili/tiejili-1.100.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 inherit font
 
 MY_PN="Tiejili"
-DESCRIPTION="An open-source font that extends  Reggae One to Chinese."
+DESCRIPTION="An open-source font that extends  Reggae One to Chinese"
 HOMEPAGE="https://github.com/Buernia/Tiejili"
 SRC_URI="https://github.com/Buernia/Tiejili/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 S="${WORKDIR}/${MY_PN}-${PV}"

--- a/media-fonts/zhudou/zhudou-2.000.ebuild
+++ b/media-fonts/zhudou/zhudou-2.000.ebuild
@@ -7,7 +7,7 @@ inherit font
 
 MY_PN="Zhudou-Sans"
 
-DESCRIPTION="A font family for CJK symbols and punctuation, derived from Noto Sans."
+DESCRIPTION="A font family for CJK symbols and punctuation, derived from Noto Sans"
 HOMEPAGE="https://github.com/Buernia/Zhudou-Sans"
 SRC_URI="https://github.com/Buernia/Zhudou-Sans/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
 

--- a/media-gfx/tgs2png/tgs2png-9999.ebuild
+++ b/media-gfx/tgs2png/tgs2png-9999.ebuild
@@ -7,7 +7,7 @@ EGIT_REPO_URI="https://github.com/zevlg/tgs2png.git"
 
 inherit cmake git-r3
 
-DESCRIPTION="Convert Telegram's animated stickers in TGS format into series of PNG images."
+DESCRIPTION="Convert Telegram's animated stickers in TGS format into series of PNG images"
 HOMEPAGE="https://github.com/zevlg/tgs2png"
 
 LICENSE="GPL-3"

--- a/media-plugins/osdlyrics/osdlyrics-0.5.15.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-0.5.15.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3_{12..13} )
 
 inherit python-r1 autotools optfeature xdg
 
-DESCRIPTION="Standalone lyrics fetcher/displayer (windowed and OSD mode)."
+DESCRIPTION="Standalone lyrics fetcher/displayer (windowed and OSD mode)"
 HOMEPAGE="https://github.com/osdlyrics/osdlyrics"
 
 LICENSE="GPL-3"

--- a/media-plugins/osdlyrics/osdlyrics-9999.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-9999.ebuild
@@ -6,7 +6,7 @@ PYTHON_COMPAT=( python3_{12..13} )
 
 inherit python-r1 autotools optfeature xdg
 
-DESCRIPTION="Standalone lyrics fetcher/displayer (windowed and OSD mode)."
+DESCRIPTION="Standalone lyrics fetcher/displayer (windowed and OSD mode)"
 HOMEPAGE="https://github.com/osdlyrics/osdlyrics"
 
 LICENSE="GPL-3"

--- a/media-sound/euphonica/euphonica-0.98.1.ebuild
+++ b/media-sound/euphonica/euphonica-0.98.1.ebuild
@@ -14,7 +14,7 @@ RUST_MIN_VER="1.88.0"
 
 inherit cargo meson gnome2-utils xdg
 
-DESCRIPTION="An MPD client with delusions of grandeur, made with Rust, GTK and Libadwaita."
+DESCRIPTION="An MPD client with delusions of grandeur, made with Rust, GTK and Libadwaita"
 HOMEPAGE="https://github.com/htkhiem/euphonica"
 SRC_URI="
 	https://github.com/htkhiem/euphonica/archive/v${PV}-beta.1.tar.gz -> ${P}.tar.gz

--- a/media-sound/splayer/splayer-3.0.0.ebuild
+++ b/media-sound/splayer/splayer-3.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 inherit desktop unpacker xdg
-DESCRIPTION="A cross-platform music player."
+DESCRIPTION="A cross-platform music player"
 
 MY_PN="SPlayer"
 HOMEPAGE="https://splayer.imsyy.top/"

--- a/net-analyzer/nali/nali-0.8.1.ebuild
+++ b/net-analyzer/nali/nali-0.8.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 inherit go-module
 
-DESCRIPTION="An offline tool for querying IP geographic information and CDN provider."
+DESCRIPTION="An offline tool for querying IP geographic information and CDN provider"
 HOMEPAGE="https://github.com/zu1k/nali"
 
 SRC_URI="

--- a/net-analyzer/nali/nali-0.8.1_p20250221.ebuild
+++ b/net-analyzer/nali/nali-0.8.1_p20250221.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 inherit go-module
 
-DESCRIPTION="An offline tool for querying IP geographic information and CDN provider."
+DESCRIPTION="An offline tool for querying IP geographic information and CDN provider"
 HOMEPAGE="https://github.com/zu1k/nali"
 EGIT_COMMIT="a41f45b7d9f0ad69631a19a21bd60ae00a777126"
 SRC_URI="

--- a/net-dns/dnsmasq-china-list/dnsmasq-china-list-9999.ebuild
+++ b/net-dns/dnsmasq-china-list/dnsmasq-china-list-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit git-r3
 
-DESCRIPTION="Chinese-specific configuration to improve your favorite DNS server."
+DESCRIPTION="Chinese-specific configuration to improve your favorite DNS server"
 HOMEPAGE="https://github.com/felixonmars/dnsmasq-china-list"
 
 EGIT_REPO_URI="https://github.com/felixonmars/dnsmasq-china-list.git"

--- a/net-misc/remmina-plugin-rustdesk/remmina-plugin-rustdesk-1.0.0.0-r1.ebuild
+++ b/net-misc/remmina-plugin-rustdesk/remmina-plugin-rustdesk-1.0.0.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 CMAKE_MAKEFILE_GENERATOR=ninja
 inherit xdg cmake
 
-DESCRIPTION="A protocol plugin for Remmina to launch a Rustdesk connection."
+DESCRIPTION="A protocol plugin for Remmina to launch a Rustdesk connection"
 HOMEPAGE="https://www.muflone.com/remmina-plugin-rustdesk/"
 _BUILDERVER="1.4.27.0"
 SRC_URI="

--- a/net-proxy/Xray/Xray-26.3.27.ebuild
+++ b/net-proxy/Xray/Xray-26.3.27.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit go-module systemd
 
-DESCRIPTION="Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support."
+DESCRIPTION="Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support"
 HOMEPAGE="https://xtls.github.io/ https://github.com/XTLS/Xray-core"
 SRC_URI="https://github.com/XTLS/Xray-core/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 	https://github.com/gentoo-zh-drafts/Xray-core/releases/download/v${PV}/Xray-core-${PV}-vendor.tar.xz"

--- a/net-proxy/Xray/Xray-26.5.9.ebuild
+++ b/net-proxy/Xray/Xray-26.5.9.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit go-module systemd
 
-DESCRIPTION="Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support."
+DESCRIPTION="Xray, Penetrates Everything. Also the best v2ray-core, with XTLS support"
 HOMEPAGE="https://xtls.github.io/ https://github.com/XTLS/Xray-core"
 SRC_URI="https://github.com/XTLS/Xray-core/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 	https://github.com/gentoo-zh-drafts/Xray-core/releases/download/v${PV}/Xray-core-${PV}-vendor.tar.xz"

--- a/net-proxy/clash-verge-bin/clash-verge-bin-2.4.3.ebuild
+++ b/net-proxy/clash-verge-bin/clash-verge-bin-2.4.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="(Continuation) of Clash Meta GUI based on Tauri. "
+DESCRIPTION="(Continuation) of Clash Meta GUI based on Tauri"
 HOMEPAGE="https://github.com/clash-verge-rev/clash-verge-rev"
 
 if [[ ${PV} == 9999 ]]; then

--- a/net-proxy/clash-verge-bin/clash-verge-bin-9999.ebuild
+++ b/net-proxy/clash-verge-bin/clash-verge-bin-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop unpacker xdg
 
-DESCRIPTION="(Continuation) of Clash Meta GUI based on Tauri."
+DESCRIPTION="(Continuation) of Clash Meta GUI based on Tauri"
 HOMEPAGE="https://github.com/clash-verge-rev/clash-verge-rev"
 
 if [[ ${PV} == 9999 ]]; then

--- a/net-proxy/hysteria/hysteria-2.9.1.ebuild
+++ b/net-proxy/hysteria/hysteria-2.9.1.ebuild
@@ -6,7 +6,7 @@ inherit go-module systemd
 
 COMMIT_ID="64c396385631579598cc29d5561bff98c439772f"
 
-DESCRIPTION="A powerful, lightning fast and censorship resistant proxy."
+DESCRIPTION="A powerful, lightning fast and censorship resistant proxy"
 HOMEPAGE="https://github.com/apernet/hysteria"
 
 SRC_URI="

--- a/net-proxy/hysteria/hysteria-2.9.3.ebuild
+++ b/net-proxy/hysteria/hysteria-2.9.3.ebuild
@@ -6,7 +6,7 @@ inherit go-module systemd
 
 COMMIT_ID="2d973f9513ef661d1922d6d14acb37945caef47d"
 
-DESCRIPTION="A powerful, lightning fast and censorship resistant proxy."
+DESCRIPTION="A powerful, lightning fast and censorship resistant proxy"
 HOMEPAGE="https://github.com/apernet/hysteria"
 
 SRC_URI="

--- a/net-proxy/juicity/juicity-0.5.0.ebuild
+++ b/net-proxy/juicity/juicity-0.5.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit go-module systemd
 
-DESCRIPTION="juicity is a quic-based proxy protocol."
+DESCRIPTION="juicity is a quic-based proxy protocol"
 HOMEPAGE="https://github.com/juicity/juicity"
 SRC_URI="https://github.com/juicity/juicity/releases/download/v${PV}/juicity-full-src.zip -> ${P}.zip"
 

--- a/net-proxy/shadowsocks-rust/shadowsocks-rust-1.24.0.ebuild
+++ b/net-proxy/shadowsocks-rust/shadowsocks-rust-1.24.0.ebuild
@@ -14,7 +14,7 @@ inherit cargo linux-info systemd
 
 MY_PV=${PV/_alpha/-alpha.}
 
-DESCRIPTION="shadowsocks is a fast tunnel proxy that helps you bypass firewalls."
+DESCRIPTION="shadowsocks is a fast tunnel proxy that helps you bypass firewalls"
 HOMEPAGE="https://github.com/shadowsocks/shadowsocks-rust"
 SRC_URI="
 	https://github.com/shadowsocks/shadowsocks-rust/archive/v${MY_PV}.tar.gz -> ${P}.tar.gz

--- a/net-proxy/v2ray/v2ray-5.51.2.ebuild
+++ b/net-proxy/v2ray/v2ray-5.51.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 inherit go-module systemd
 
-DESCRIPTION="A platform for building proxies to bypass network restrictions."
+DESCRIPTION="A platform for building proxies to bypass network restrictions"
 HOMEPAGE="https://www.v2fly.org/"
 SRC_URI="
 	https://github.com/v2fly/v2ray-core/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz

--- a/net-vpn/sstp-server/sstp-server-0.7.2.ebuild
+++ b/net-vpn/sstp-server/sstp-server-0.7.2.ebuild
@@ -8,7 +8,7 @@ PYTHON_COMPAT=( python3_{12..15} )
 
 inherit systemd distutils-r1
 
-DESCRIPTION="A Secure Socket Tunneling Protocol (SSTP) server implemented in Python."
+DESCRIPTION="A Secure Socket Tunneling Protocol (SSTP) server implemented in Python"
 HOMEPAGE="https://github.com/sorz/sstp-server/"
 SRC_URI="https://github.com/sorz/sstp-server/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 

--- a/sys-fs/jmtpfs/jmtpfs-0.5.ebuild
+++ b/sys-fs/jmtpfs/jmtpfs-0.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="A FUSE and libmtp based filesystem for accessing MTP devices."
+DESCRIPTION="A FUSE and libmtp based filesystem for accessing MTP devices"
 HOMEPAGE="http://research.jacquette.com/jmtpfs-exchanging-files-between-android-devices-and-linux"
 SRC_URI="https://github.com/JasonFerrara/jmtpfs/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 

--- a/sys-kernel/xanmod-rt/xanmod-rt-6.0.11.ebuild
+++ b/sys-kernel/xanmod-rt/xanmod-rt-6.0.11.ebuild
@@ -14,7 +14,7 @@ RDEPEND="
 inherit kernel-2
 detect_version
 
-DESCRIPTION="XanMod RT sources and CJKTTY options."
+DESCRIPTION="XanMod RT sources and CJKTTY options"
 HOMEPAGE="https://xanmod.org
 		https://github.com/zhmars/cjktty-patches"
 XANMOD_VERSION="1"

--- a/sys-kernel/xanmod-rt/xanmod-rt-6.12.31.ebuild
+++ b/sys-kernel/xanmod-rt/xanmod-rt-6.12.31.ebuild
@@ -8,7 +8,7 @@ KERNEL_IUSE_MODULES_SIGN=1
 
 inherit kernel-build toolchain-funcs
 
-DESCRIPTION="XanMod RT sources w/ genpatches and CJKTTY options."
+DESCRIPTION="XanMod RT sources w/ genpatches and CJKTTY options"
 HOMEPAGE="https://xanmod.org
 		https://github.com/zhmars/cjktty-patches
 		https://github.com/bigshans/cjktty-patches"

--- a/sys-kernel/xanmod-sources/xanmod-sources-7.1.3.ebuild
+++ b/sys-kernel/xanmod-sources/xanmod-sources-7.1.3.ebuild
@@ -12,7 +12,7 @@ detect_version
 detect_arch
 
 MY_P=linux-${PV%.*}
-DESCRIPTION="Full XanMod source, including the Gentoo patchset and other patch options."
+DESCRIPTION="Full XanMod source, including the Gentoo patchset and other patch options"
 HOMEPAGE="https://xanmod.org"
 
 XANMOD_VERSION="1"

--- a/www-apps/cherry-studio-bin/cherry-studio-bin-1.9.11.ebuild
+++ b/www-apps/cherry-studio-bin/cherry-studio-bin-1.9.11.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 inherit desktop xdg
 
-DESCRIPTION="Cherry Studio is a desktop client that supports for multiple LLM providers."
+DESCRIPTION="Cherry Studio is a desktop client that supports for multiple LLM providers"
 HOMEPAGE="https://github.com/CherryHQ/cherry-studio"
 URL_PREFIX="https://github.com/CherryHQ/cherry-studio/releases/download/v${PV}/Cherry-Studio-${PV}"
 SRC_URI="

--- a/x11-themes/fcitx-breeze/fcitx-breeze-3.1.0.ebuild
+++ b/x11-themes/fcitx-breeze/fcitx-breeze-3.1.0.ebuild
@@ -8,7 +8,7 @@ inherit python-any-r1
 
 EGIT_COMMIT=59456757ca1f0736dcf03b507f661a3693f5b51d
 
-DESCRIPTION="Fcitx5 theme to match KDE's Breeze style."
+DESCRIPTION="Fcitx5 theme to match KDE's Breeze style"
 HOMEPAGE="https://gitlab.com/scratch-er/fcitx5-breeze"
 SRC_URI="https://gitlab.com/scratch-er/fcitx5-breeze/-/archive/v${PV}/fcitx5-breeze-${PV}.tar.bz2"
 

--- a/x11-wm/chamferwm/chamferwm-9999.ebuild
+++ b/x11-wm/chamferwm/chamferwm-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-DESCRIPTION="A tiling X11 window manager with Vulkan compositor."
+DESCRIPTION="A tiling X11 window manager with Vulkan compositor"
 HOMEPAGE="https://github.com/jaelpark/chamferwm"
 
 EGIT_REPO_URI="https://github.com/jaelpark/chamferwm.git git://github.com/jaelpark/chamferwm.git"


### PR DESCRIPTION
pkgcheck BadDescription: DESCRIPTION should not end with a full stop.

Drops the trailing full stop from 64 ebuilds across 48 packages. Metadata
only, no revbump. Ellipsis (`...`) endings are left untouched.

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
