### PR TITLE
*/*: fetch deps from gentoo-zh/gentoo-deps (migrate off personal fork)

### DIFF
--- a/media-sound/netease-cloud-music-gtk/netease-cloud-music-gtk-2.5.3.ebuild
+++ b/media-sound/netease-cloud-music-gtk/netease-cloud-music-gtk-2.5.3.ebuild
@@ -19,7 +19,7 @@ HOMEPAGE="https://github.com/gmg137/netease-cloud-music-gtk"
 
 SRC_URI="
 	https://github.com/gmg137/netease-cloud-music-gtk/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz
-	https://github.com/liuyujielol/gentoo-go-deps/releases/download/${P}/${P}-crates.tar.xz
+	https://github.com/gentoo-zh/gentoo-deps/releases/download/${P}/${P}-crates.tar.xz
 	https://github.com/gmg137/netease-cloud-music-api/archive/refs/tags/${NCM_API_TAG}.tar.gz ->
 	netease-cloud-music-api-${NCM_API_TAG}.tar.gz
 "

--- a/net-proxy/clash-verge-rev/clash-verge-rev-2.5.1.ebuild
+++ b/net-proxy/clash-verge-rev/clash-verge-rev-2.5.1.ebuild
@@ -24,8 +24,8 @@ HOMEPAGE="
 	https://www.clashverge.dev
 	https://github.com/clash-verge-rev/clash-verge-rev
 "
-# Web dist tarball generared from liuyujielol/gentoo-go-deps/blob/cvr/.github/workflows/generator.yml
-DEPS_URI="https://github.com/liuyujielol/gentoo-go-deps/releases/download"
+# Web dist tarball generared from gentoo-zh/gentoo-deps/blob/cvr/.github/workflows/generator.yml
+DEPS_URI="https://github.com/gentoo-zh/gentoo-deps/releases/download"
 SRC_URI="
 	https://github.com/clash-verge-rev/clash-verge-rev/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 	${DEPS_URI}/${P}/${P/-rev/}-crates.tar.xz

--- a/net-proxy/v2rayA/v2rayA-2.2.7.5.ebuild
+++ b/net-proxy/v2rayA/v2rayA-2.2.7.5.ebuild
@@ -13,9 +13,9 @@ SRC_URI="
 	https://github.com/v2rayA/v2rayA/releases/download/v${PV}/web.tar.gz -> ${P}-web.tar.gz
 "
 # maintainer generated deps pack
-# generated with liuyujielol/gentoo-go-deps/.github/workflows/generator.yml
+# generated with gentoo-zh/gentoo-deps/.github/workflows/generator.yml
 SRC_URI+="
-	https://github.com/liuyujielol/gentoo-go-deps/releases/download/${P}/${P}-deps.tar.xz
+	https://github.com/gentoo-zh/gentoo-deps/releases/download/${P}/${P}-deps.tar.xz
 "
 
 LICENSE="AGPL-3"


### PR DESCRIPTION
Move the per-version dependency packs for these three packages from the personal fork `liuyujielol/gentoo-go-deps` to the org-hosted `gentoo-zh/gentoo-deps`:

- net-proxy/v2rayA (Go deps) — **built + installed locally from the new URL** ✓
- net-proxy/clash-verge-rev (Rust crates + service-ipc crates)
- media-sound/netease-cloud-music-gtk (Rust crates)

The tarballs were mirrored **byte-identical** (same BLAKE2B/SHA512), so the Manifests are unchanged — only `SRC_URI` points at the org release. Each mirrored release notes its source.

clash-verge-rev / netease not fully built here (heavy Tauri/GTK); their deps fetch + Manifest verify from the new URL.