### PR TITLE
*/*: QA cleanup — DESCRIPTION full stops + ebuild whitespace

### DIFF
--- a/dev-python/edalize/edalize-0.6.8.ebuild
+++ b/dev-python/edalize/edalize-0.6.8.ebuild
@@ -13,7 +13,7 @@ PATCHES=(
 )
 
 DESCRIPTION="
-	Library for interfacing EDA tools.
+	Library for interfacing EDA tools
 "
 HOMEPAGE="
 	https://github.com/olofk/edalize/

--- a/dev-python/fusesoc/fusesoc-2.4.4.ebuild
+++ b/dev-python/fusesoc/fusesoc-2.4.4.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="
-Award-winnning package manager and build abstraction tool for HDL code.
+Award-winnning package manager and build abstraction tool for HDL code
 "
 HOMEPAGE="
 	https://github.com/olofk/fusesoc/

--- a/dev-python/fusesoc/fusesoc-2.4.6.ebuild
+++ b/dev-python/fusesoc/fusesoc-2.4.6.ebuild
@@ -13,7 +13,7 @@ PATCHES=(
 )
 
 DESCRIPTION="
-Award-winnning package manager and build abstraction tool for HDL code.
+Award-winnning package manager and build abstraction tool for HDL code
 "
 HOMEPAGE="
 	https://github.com/olofk/fusesoc/

--- a/dev-python/okonomiyaki/okonomiyaki-3.0.0.ebuild
+++ b/dev-python/okonomiyaki/okonomiyaki-3.0.0.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="
-	Self-contained library to deal with metadata in egg and runtime archives.
+	Self-contained library to deal with metadata in egg and runtime archives
 "
 HOMEPAGE="
 	https://github.com/enthought/okonomiyaki

--- a/dev-python/simplesat/simplesat-0.9.2.ebuild
+++ b/dev-python/simplesat/simplesat-0.9.2.ebuild
@@ -9,7 +9,7 @@ PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="
-	Prototype for SAT-based dependency handling.
+	Prototype for SAT-based dependency handling
 "
 HOMEPAGE="
 	https://github.com/enthought/sat-solver

--- a/net-misc/baidunetdisk/baidunetdisk-8.5.2.ebuild
+++ b/net-misc/baidunetdisk/baidunetdisk-8.5.2.ebuild
@@ -34,8 +34,8 @@ QA_PREBUILT="*"
 src_install() {
 	insinto /opt
 	doins -r opt/"${PN}"
-    find "${D}" -type d -name "node_gyp_bins" -exec rm -rf {} + 2>/dev/null
-    find "${D}" -type d -empty -delete 2>/dev/null
+	find "${D}" -type d -name "node_gyp_bins" -exec rm -rf {} + 2>/dev/null
+	find "${D}" -type d -empty -delete 2>/dev/null
 	fperms +x /opt/"${PN}"/"${PN}"
 	dosym -r /opt/{"${PN}"/"${PN}",bin/"${PN}"}
 


### PR DESCRIPTION
Small pkgcheck fixes, metadata/whitespace only (no revbump):

- **BadDescription** (5 ebuilds): drop the trailing full stop from DESCRIPTION on dev-python/{edalize, fusesoc (2 versions), okonomiyaki, simplesat}. These have a multi-line DESCRIPTION, which the earlier treewide full-stop pass didn't match.
- **WhitespaceFound**: net-misc/baidunetdisk indented two src_install lines with 4 spaces instead of a tab.

pkgcheck BadDescription + WhitespaceFound on these packages: 0 after.