### PR TITLE
*/*: QA cleanup - variable order and indentation

### DIFF
--- a/app-crypt/cotp/cotp-1.9.10.ebuild
+++ b/app-crypt/cotp/cotp-1.9.10.ebuild
@@ -9,50 +9,50 @@ DESCRIPTION="command-line TOTP/HOTP authenticator app"
 HOMEPAGE="https://github.com/replydev/cotp"
 
 if [[ ${PV} == 9999 ]]; then
-    inherit git-r3
-    EGIT_REPO_URI="https://github.com/replydev/cotp.git"
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/replydev/cotp.git"
 else
-    SRC_URI="
-        https://github.com/replydev/cotp/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
+	SRC_URI="
+		https://github.com/replydev/cotp/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 		https://github.com/huaji2369/ebuild-crate-dist-replydev-cotp/releases/download/v${PV}/${P}-crates.tar.xz
-        ${CARGO_CRATE_URIS}
-    "
-    KEYWORDS="~amd64 ~arm64"
+		${CARGO_CRATE_URIS}
+	"
+	KEYWORDS="~amd64 ~arm64"
 fi
 LICENSE="GPL-3+"
 # Dependent crate licenses
 LICENSE+="
 	Apache-2.0
-    BSD-2
-    BSD
-    Boost-1.0
-    ISC
-    MIT
-    MPL-2.0
-    Unicode-3.0
+	BSD-2
+	BSD
+	Boost-1.0
+	ISC
+	MIT
+	MPL-2.0
+	Unicode-3.0
 	Unicode-DFS-2016
-    WTFPL-2
-    ZLIB
+	WTFPL-2
+	ZLIB
 "
 SLOT="0"
 IUSE="converter"
 RDEPEND="
-    x11-libs/libxcb
-    x11-libs/libxkbcommon
+	x11-libs/libxcb
+	x11-libs/libxkbcommon
 "
 DEPEND="${RDEPEND}"
 
 src_unpack() {
-    if [[ ${PV} == 9999 ]]; then
-        git-r3_src_unpack
-        cargo_live_src_unpack
-    else
-        cargo_src_unpack
-    fi
+	if [[ ${PV} == 9999 ]]; then
+		git-r3_src_unpack
+		cargo_live_src_unpack
+	else
+		cargo_src_unpack
+	fi
 }
 
 src_install() {
-    cargo_src_install
+	cargo_src_install
 	use converter && (
 		insinto "/usr/share/${P}/converters/"
 		doins -r converters/

--- a/app-crypt/cotp/cotp-9999.ebuild
+++ b/app-crypt/cotp/cotp-9999.ebuild
@@ -9,50 +9,50 @@ DESCRIPTION="command-line TOTP/HOTP authenticator app"
 HOMEPAGE="https://github.com/replydev/cotp"
 
 if [[ ${PV} == 9999 ]]; then
-    inherit git-r3
-    EGIT_REPO_URI="https://github.com/replydev/cotp.git"
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/replydev/cotp.git"
 else
-    SRC_URI="
-        https://github.com/replydev/cotp/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
+	SRC_URI="
+		https://github.com/replydev/cotp/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz
 		https://github.com/huaji2369/ebuild-crate-dist-replydev-cotp/releases/download/v${PV}/${P}-crates.tar.xz
-        ${CARGO_CRATE_URIS}
-    "
-    KEYWORDS="~amd64 ~arm64"
+		${CARGO_CRATE_URIS}
+	"
+	KEYWORDS="~amd64 ~arm64"
 fi
 LICENSE="GPL-3+"
 # Dependent crate licenses
 LICENSE+="
 	Apache-2.0
-    BSD-2
-    BSD
-    Boost-1.0
-    ISC
-    MIT
-    MPL-2.0
-    Unicode-3.0
+	BSD-2
+	BSD
+	Boost-1.0
+	ISC
+	MIT
+	MPL-2.0
+	Unicode-3.0
 	Unicode-DFS-2016
-    WTFPL-2
-    ZLIB
+	WTFPL-2
+	ZLIB
 "
 SLOT="0"
 IUSE="converter"
 RDEPEND="
-    x11-libs/libxcb
-    x11-libs/libxkbcommon
+	x11-libs/libxcb
+	x11-libs/libxkbcommon
 "
 DEPEND="${RDEPEND}"
 
 src_unpack() {
-    if [[ ${PV} == 9999 ]]; then
-        git-r3_src_unpack
-        cargo_live_src_unpack
-    else
-        cargo_src_unpack
-    fi
+	if [[ ${PV} == 9999 ]]; then
+		git-r3_src_unpack
+		cargo_live_src_unpack
+	else
+		cargo_src_unpack
+	fi
 }
 
 src_install() {
-    cargo_src_install
+	cargo_src_install
 	use converter && (
 		insinto "/usr/share/${P}/converters/"
 		doins -r converters/

--- a/app-crypt/cotp/metadata.xml
+++ b/app-crypt/cotp/metadata.xml
@@ -5,7 +5,7 @@
 		<email>3117086599@qq.com</email>
 		<name>huaji2369</name>
 	</maintainer>
-    <upstream>
-        <remote-id type="github">replydev/cotp</remote-id>
-    </upstream>
+	<upstream>
+		<remote-id type="github">replydev/cotp</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
+++ b/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
@@ -9,6 +9,7 @@ inherit meson python-any-r1 virtualx xdg
 DESCRIPTION="jonaburg's picom fork with dual_kawase blur and rounded corners"
 HOMEPAGE="https://github.com/jonaburg/picom"
 SRC_URI="https://github.com/jonaburg/picom/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+S="${WORKDIR}/picom-${PV}"
 
 LICENSE="MPL-2.0 MIT"
 SLOT="0"
@@ -45,8 +46,6 @@ BDEPEND="virtual/pkgconfig
 "
 
 DOCS=( README.md picom.sample.conf )
-
-S="${WORKDIR}/picom-${PV}"
 
 src_configure() {
 	local emesonargs=(


### PR DESCRIPTION
承 #10883，續掃全 overlay 的簡單 QA：

- **VariableOrderWrong**：picom-jonaburg —— `S` 移到 `SRC_URI` 之後
- **WhitespaceFound / PkgMetadataXmlIndentation**：cotp 兩個 ebuild 與 metadata.xml 行首空白改 tab

純機械改動，pkgcheck 對應項清乾淨。

（原本另含 looking-glass、oh-my-git-bin、cider、deepin-wine-helper 的 cosmetic 修正，但這幾個包 CI emerge 因既有原因失敗——RESTRICT=fetch、老 beta 編不過、上游下載已死——與本次改動無關，故移除，只留 CI 過綠的部分。）