### PR TITLE
profiles: unmask autopxd2 and last rite dead deepin-wine ecosystem packages

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -3,7 +3,6 @@
 # the vocotype stack, but vocotype upstream is no longer maintained.
 # Removal on 2026-07-30 unless a new maintainer steps up.
 app-i18n/vocotype
-dev-python/autopxd2
 dev-python/funasr-onnx
 dev-python/jieba
 dev-python/kaldi-native-fbank

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -20,3 +20,9 @@ dev-python/soxr
 app-emulation/deepin-wine-helper
 app-emulation/deepin-wine-plugin
 app-misc/ccal
+
+# Huang Rui <vowstar@gmail.com> (2026-07-13)
+# The deepin-wine base packages are last rited, so this AppArmor profile has
+# no remaining target to protect
+# Removal on 2026-08-13
+sec-policy/apparmor-profile-deepinwine

--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -12,3 +12,11 @@ dev-python/numba
 dev-python/onnxruntime
 dev-python/sounddevice
 dev-python/soxr
+
+# Huang Rui <vowstar@gmail.com> (2026-07-13)
+# Upstream download is dead and overlay distfiles are not mirrored, so these
+# packages are uninstallable, re-home upstream or they will be removed
+# Removal on 2026-08-13
+app-emulation/deepin-wine-helper
+app-emulation/deepin-wine-plugin
+app-misc/ccal


### PR DESCRIPTION
Closes #10889
Closes #10887
Closes #10884

autopxd2 was masked with the vocotype stack by mistake, it is a build
dep of pyrime and upstream is alive, so it is unmasked

deepin-wine-helper, deepin-wine-plugin and ccal have dead upstream
downloads with no mirrored distfiles, last rited with a 30 day window

cajviewer is not masked, its cnki download is live from China mainland
and only looks dead to foreign scans, documented in the ebuild instead

apparmor-profile-deepinwine is last rited too since the deepin-wine base
it protects is going away and nothing else depends on it

@oatiz @123485k please re-home upstream if a live source exists