### PR TITLE
.github/workflows/overlay.toml: zen-browser-bin 'b' is not a beta suffix

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1811,8 +1811,6 @@ github_account = ["irort", "Zakkaus", "gouwazi"]
 source = "github"
 github = "zen-browser/desktop"
 use_latest_release = true
-from_pattern = "(.*)b"
-to_pattern = "\\1_beta"
 github_account = ["zakkaus", "gouwazi"]
 
 ["www-servers/darkhttpd"]


### PR DESCRIPTION
zen-browser's release tags carry a trailing 'b' as part of the version string
(releases are named "Release build - 1.21.7b", prerelease=false); it is not a
beta marker. The (.*)b -> \1_beta transform rewrote the tag to 1.21.7_beta, which
never matches the 1.21.7b ebuild, so nvchecker kept filing bogus "bump to
1.21.7_beta" issues even when already at 1.21.7b (#10952). Drop the transform so
nvchecker compares the raw tag.

zen 的發行 tag 結尾的 b 是版本字串的一部分(release 名為「Release build -
1.21.7b」、prerelease=false),不是 beta。(.*)b -> \1_beta 把 tag 改寫成
1.21.7_beta,永遠對不上 1.21.7b 的 ebuild,所以在已是 1.21.7b 時 nvchecker 還一直
開假的 bump issue(#10952)。移除轉換,讓它用原始 tag 比對。

Closes #10952
