### PR TITLE
.github/workflows/overlay.toml: track vintagestory and vintagestory-server

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -855,6 +855,12 @@ use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
 
+["games-action/vintagestory"]
+source = "regex"
+url = "https://api.vintagestory.at/lateststable.txt"
+regex = "([\\d.]+)"
+github_account = ["liuyujielol", "gouwazi"]
+
 ["games-arcade/osu-lazer-bin"]
 source = "github"
 github = "ppy/osu"
@@ -870,6 +876,12 @@ github_account = "Puqns67"
 source = "github"
 github = "git-learning-game/oh-my-git"
 use_latest_tag = true
+
+["games-server/vintagestory-server"]
+source = "regex"
+url = "https://api.vintagestory.at/lateststable.txt"
+regex = "([\\d.]+)"
+github_account = ["liuyujielol", "gouwazi"]
 
 ["gui-apps/crystal-dock"]
 source = "github"


### PR DESCRIPTION
Add nvchecker coverage for the two Vintage Story packages now maintained by the
gentoo-zh project (metadata assigned in #10927). Their version comes from
https://api.vintagestory.at/lateststable.txt (plain "1.22.3"), so a regex source.
vintagestory is already at 1.22.3; vintagestory-server is at 1.21.0 and will get a
bump reminder to 1.22.3.

dev-embedded/at32workbench and dev-util/trae-ide were considered but skipped: the
Artery tools.jsp page is JS-rendered and Trae's CDN exposes no clean latest-version
endpoint, so neither has a reliable source to track without producing noise.

替 gentoo-zh 專案現在維護的兩個 Vintage Story 包加上 nvchecker 追蹤(metadata 於
#10927 指派)。版本取自 api.vintagestory.at/lateststable.txt(純文字 1.22.3),用
regex。vintagestory 已是 1.22.3;vintagestory-server 還在 1.21.0,追了會提醒升到
1.22.3。

at32workbench 與 trae-ide 評估後跳過:Artery 頁面是 JS 動態、Trae CDN 無乾淨的版本
端點,沒有可靠來源、硬加會噴錯。
