### PR TITLE
ci: enable keyring for webkit-gtk binhost

### DIFF
--- a/.github/workflows/emerge-on-pr.yml
+++ b/.github/workflows/emerge-on-pr.yml
@@ -140,6 +140,7 @@ jobs:
         mkdir -p /etc/portage/package.use
         cat >> /etc/portage/package.use/ci-binhost << EOF
         dev-qt/qtwebengine bindist
+        net-libs/webkit-gtk keyring
         EOF
         cat /etc/portage/make.conf
 


### PR DESCRIPTION
The OpenRC emerge jobs cannot use the official WebKitGTK binary because the profile resolves `-keyring -systemd`, while the available non-systemd binpkg uses `keyring -systemd`. This causes WebKitGTK to build from source and leaves PR jobs running for hours.

Align the CI-only WebKitGTK USE configuration with the official binhost, following the existing QtWebEngine `bindist` workaround.

Testing:
- Parsed `.github/workflows/emerge-on-pr.yml` with Ruby YAML
- `git diff --check`
- `pkgcheck scan --commits --net`
- Verified `gentoo/stage3:amd64-desktop-openrc` selects binary `net-libs/webkit-gtk-2.52.3-r411-3` with `keyring -systemd`
- Verified `gentoo/stage3:amd64-desktop-systemd` selects binary `net-libs/webkit-gtk-2.52.3-r411-2` with `keyring systemd`