### PR TITLE
nvchecker.yml: pass relation.md to bumpbot for dependency hints

### DIFF
--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -129,6 +129,12 @@ jobs:
       with:
         path: 'gentoo-zh'
 
+    - name: Checkout deps-table
+      uses: actions/checkout@v7
+      with:
+        ref: deps-table
+        path: deps-table
+
     - name: update issues
       timeout-minutes: 1
       env:
@@ -137,4 +143,4 @@ jobs:
         oldver: ${{ matrix.oldver }}
         GITHUB_TOKEN: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }} # https://github.com/gentoo-zh/overlay/pull/3130
       run: |
-        go run . --file gentoo-zh/.github/workflows/overlay.toml --name "$name" --newver "$newver" --oldver "$oldver"
+        go run . --file gentoo-zh/.github/workflows/overlay.toml --relation deps-table/relation.md --name "$name" --newver "$newver" --oldver "$oldver"


### PR DESCRIPTION
讓 issues-bumper 也 checkout `deps-table` 分支、把 `relation.md` 透過 `--relation`
傳給 bumpbot,bump issue 就會附上反向依賴提示。

需先併入 gentoo-zh-drafts/bumpbot#3(加了 `--relation` 旗標)。

Check out the `deps-table` branch in issues-bumper and pass `relation.md` to
bumpbot via `--relation`, so bump issues include a reverse-dependency hint.
Needs gentoo-zh-drafts/bumpbot#3 (which adds the `--relation` flag) merged first.
