### PR TITLE
.github/workflows/overlay.toml: stop tracking a dup and 3 archived upstreams

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -276,12 +276,14 @@ use_latest_release = true
 prefix = "v"
 github_account = "liangyongxiang"
 
-["app-misc/cc-switch-bin"]
-source = "github"
-github = "farion1231/cc-switch"
-use_latest_release = true
-prefix = "v"
-github_account = ["liangyongxiang", "gouwazi"]
+# FIXME: github graphql api confuses cc-switch and cc-switch-bin (same repo
+# farion1231/cc-switch), so track only the source cc-switch.
+# ["app-misc/cc-switch-bin"]
+# source = "github"
+# github = "farion1231/cc-switch"
+# use_latest_release = true
+# prefix = "v"
+# github_account = ["liangyongxiang", "gouwazi"]
 
 ["app-misc/claude-desktop"]
 source = "apt"
@@ -1326,26 +1328,29 @@ use_latest_release = true
 prefix = "v"
 github_account = "123485k"
 
-["net-misc/bbdown-bin"]
-source = "github"
-github = "nilaoda/BBDown"
-use_latest_release = true
-prefix = "v"
-github_account = "gouwazi"
+# upstream archived, no new releases
+# ["net-misc/bbdown-bin"]
+# source = "github"
+# github = "nilaoda/BBDown"
+# use_latest_release = true
+# prefix = "v"
+# github_account = "gouwazi"
 
-["net-misc/biliup-app-bin"]
-source = "github"
-github = "ForgQi/biliup-app"
-use_latest_release = true
-prefix = "app-v"
-github_account = "123485k"
+# upstream archived, no new releases
+# ["net-misc/biliup-app-bin"]
+# source = "github"
+# github = "ForgQi/biliup-app"
+# use_latest_release = true
+# prefix = "app-v"
+# github_account = "123485k"
 
-["net-misc/biliup-rs"]
-source = "github"
-github = "ForgQi/biliup-rs"
-use_latest_release = true
-prefix = "v"
-github_account = ["123485k", "gouwazi"]
+# upstream archived, no new releases
+# ["net-misc/biliup-rs"]
+# source = "github"
+# github = "ForgQi/biliup-rs"
+# use_latest_release = true
+# prefix = "v"
+# github_account = ["123485k", "gouwazi"]
 
 ["net-misc/bruno-bin"]
 source = "github"


### PR DESCRIPTION
清掉 4 個有問題的 nvchecker 追蹤(改成註解,不刪,若上游復活可還原):

- `cc-switch-bin`:和 `cc-switch` 追同一個 repo(farion1231/cc-switch),github
  graphql 會混淆 → 只留 source 版 `cc-switch`(照既有 chezmoi-bin / pack-cli-bin 做法)。
- `bbdown-bin` / `biliup-app-bin` / `biliup-rs`:上游 repo 已 archived,不會再有新版。

Stop tracking one duplicate and three archived upstreams (commented out, not
deleted, so they can be restored if an upstream revives):

- `cc-switch-bin` shares farion1231/cc-switch with `cc-switch` and confuses the
  github graphql api, so keep only the source `cc-switch` (same as the existing
  chezmoi-bin / pack-cli-bin handling).
- `bbdown-bin`, `biliup-app-bin`, `biliup-rs` have archived upstreams.

CC 維護者 @gouwazi @liangyongxiang @123485k
