### PR TITLE
dev-python/mwparserfromhell: enable python3_15

### DIFF
--- a/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
+++ b/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{11..15} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
Enable python3_15. Verified: builds and passes the full test suite (2005 passed, 1 skipped) under python3.15 with the C tokenizer active; all build/test deps (setuptools, setuptools-scm, pytest) already support python3_15.

This unblocks python3_15 for downstream consumers such as dev-python/pywikibot (#11032).