### PR TITLE
treewide: ebuild style and QA cleanups

### DIFF
--- a/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.45.ebuild
+++ b/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.45.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://www.deepin.org"
 
 COMMON_URI="https://home-store-packages.uniontech.com/appstore/pool/appstore/d"
 SRC_URI="${COMMON_URI}/${PN}/${PN}_${PV}-1_i386.deb"
+S=${WORKDIR}
 
 LICENSE="LGPL-2.1"
 SLOT="0"
@@ -23,7 +24,6 @@ RDEPEND="
 "
 DEPEND="${RDEPEND}"
 
-S=${WORKDIR}
 
 QA_PREBUILT="opt/deepinwine/*"
 QA_FLAGS_IGNORED="opt/deepinwine/*"

--- a/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
+++ b/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
@@ -11,6 +11,7 @@ MY_PV="${MY_PV//_/-}"
 DESCRIPTION="A low latency KVMFR application for guests with VGA PCI Passthrough"
 HOMEPAGE="https://looking-glass.io"
 SRC_URI="https://looking-glass.io/artifact/${MY_PV}/source -> ${P}.tar.gz"
+S="${WORKDIR}/${PN}-${MY_PV}"
 
 LICENSE="GPL-2"
 SLOT="0"
@@ -53,15 +54,15 @@ DEPEND="gui-libs/egl-wayland
 	)"
 RDEPEND="${DEPEND}"
 
-S="${WORKDIR}/${PN}-${MY_PV}"
-
 MY_CMAKE_PROJECT="client "
 
 src_prepare() {
 	default
 	# fix cmake compatibility issues with newer cmake versions
-	find "${S}" -name "CMakeLists.txt" -exec sed -i 's/cmake_minimum_required(VERSION 3\.5)/cmake_minimum_required(VERSION 3.10)/' {} +
-	find "${S}" -name "CMakeLists.txt" -exec sed -i 's/cmake_minimum_required(VERSION [0-9]\.[0-9])/cmake_minimum_required(VERSION 3.10)/' {} +
+	find "${S}" -name "CMakeLists.txt" -exec sed -i \
+		's/cmake_minimum_required(VERSION 3\.5)/cmake_minimum_required(VERSION 3.10)/' {} +
+	find "${S}" -name "CMakeLists.txt" -exec sed -i \
+		's/cmake_minimum_required(VERSION [0-9]\.[0-9])/cmake_minimum_required(VERSION 3.10)/' {} +
 	# add other project
 	if use host; then
 		MY_CMAKE_PROJECT+="host "

--- a/app-i18n/rime-ice/rime-ice-9999.ebuild
+++ b/app-i18n/rime-ice/rime-ice-9999.ebuild
@@ -12,7 +12,7 @@ EGIT_REPO_URI="https://github.com/iDvel/rime-ice.git"
 # === Optimization: Shallow Clone ===
 # Force shallow clone (depth=1) to save bandwidth and disk space.
 # This repo contains heavy git history which is unnecessary for deployment.
-EGIT_CLONE_TYPE="shallow"
+EGIT_MIN_CLONE_TYPE="shallow"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/dev-python/archspec/archspec-0.2.6.ebuild
+++ b/dev-python/archspec/archspec-0.2.6.ebuild
@@ -22,6 +22,7 @@ LICENSE="Apache-2.0 MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
+EPYTEST_PLUGINS=()
 distutils_enable_tests pytest
 
 src_unpack() {

--- a/dev-python/iptcinfo3/iptcinfo3-2.3.0.ebuild
+++ b/dev-python/iptcinfo3/iptcinfo3-2.3.0.ebuild
@@ -21,11 +21,5 @@ LICENSE="|| ( Artistic GPL-1+ )"
 SLOT="0"
 KEYWORDS="~amd64"
 
-BDEPEND="
-	test? (
-		dev-python/pytest[${PYTHON_USEDEP}]
-		dev-python/pytest-cov[${PYTHON_USEDEP}]
-	)
-"
-
+EPYTEST_PLUGINS=()
 distutils_enable_tests pytest

--- a/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
+++ b/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
@@ -22,4 +22,6 @@ BDEPEND="
 
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PV}
 
+EPYTEST_PLUGINS=()
+
 distutils_enable_tests pytest

--- a/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
+++ b/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
@@ -4,6 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
+DISTUTILS_EXT=1
 PYTHON_COMPAT=( python3_{11..15} )
 
 inherit distutils-r1

--- a/dev-python/nudatus/nudatus-0.0.5.ebuild
+++ b/dev-python/nudatus/nudatus-0.0.5.ebuild
@@ -23,4 +23,5 @@ PATCHES=(
 	"${FILESDIR}/${P}-python3.12-fix.patch"
 )
 
+EPYTEST_PLUGINS=()
 distutils_enable_tests pytest

--- a/dev-python/pypinyin/pypinyin-0.55.0.ebuild
+++ b/dev-python/pypinyin/pypinyin-0.55.0.ebuild
@@ -21,6 +21,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
+EPYTEST_PLUGINS=()
 distutils_enable_tests pytest
 
 src_prepare() {

--- a/dev-python/simplesat/simplesat-0.9.2.ebuild
+++ b/dev-python/simplesat/simplesat-0.9.2.ebuild
@@ -8,9 +8,7 @@ PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1 pypi
 
-DESCRIPTION="
-	Prototype for SAT-based dependency handling
-"
+DESCRIPTION="Prototype for SAT-based dependency handling"
 HOMEPAGE="
 	https://github.com/enthought/sat-solver
 	https://pypi.org/project/simplesat/

--- a/games-misc/oh-my-git-bin/oh-my-git-bin-0.6.5.ebuild
+++ b/games-misc/oh-my-git-bin/oh-my-git-bin-0.6.5.ebuild
@@ -11,6 +11,7 @@ HOMEPAGE="https://ohmygit.org/
 	https://github.com/git-learning-game/oh-my-git"
 PKG_URI="https://blinry.itch.io/oh-my-git"
 SRC_URI="${MY_PN}-linux.zip"
+S="${WORKDIR}"
 
 LICENSE="BlueOak-1.0.0"
 SLOT="0"
@@ -30,8 +31,6 @@ DEPEND="
 "
 RDEPEND="${DEPEND}"
 BDEPEND="app-arch/unzip"
-
-S="${WORKDIR}"
 
 pkg_nofetch() {
 	elog "Please download ${A} from"

--- a/media-gfx/tgs2png/tgs2png-9999.ebuild
+++ b/media-gfx/tgs2png/tgs2png-9999.ebuild
@@ -1,4 +1,4 @@
-#Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8

--- a/media-sound/cider/cider-3.1.8.ebuild
+++ b/media-sound/cider/cider-3.1.8.ebuild
@@ -84,7 +84,7 @@ src_install() {
 	insinto /opt
 	doins -r usr/lib/cider
 
-	dosym /opt/cider/Cider /usr/bin/cider
+	dosym ../../opt/cider/Cider /usr/bin/cider
 
 	fperms +x /opt/cider/Cider
 

--- a/sci-ml/llama-cpp/llama-cpp-0_pre9987.ebuild
+++ b/sci-ml/llama-cpp/llama-cpp-0_pre9987.ebuild
@@ -116,7 +116,7 @@ src_unpack() {
 			mkdir -p "${S}/tools/ui/dist"
 			einfo Downloading webui dist from huggingface bucket...
 			wget -qO - "https://huggingface.co/buckets/ggml-org/llama-ui/resolve/latest/dist.tar.gz" \
-				| tar -xzC "${S}/tools/ui/dist"
+				| tar -xzf - -C "${S}/tools/ui/dist"
 		else
 			ln -s "${WORKDIR}/llama-${MY_PV}" "${S}/tools/ui/dist" || die
 		fi

--- a/sci-ml/llama-cpp/llama-cpp-9999.ebuild
+++ b/sci-ml/llama-cpp/llama-cpp-9999.ebuild
@@ -116,7 +116,7 @@ src_unpack() {
 			mkdir -p "${S}/tools/ui/dist"
 			einfo Downloading webui dist from huggingface bucket...
 			wget -qO - "https://huggingface.co/buckets/ggml-org/llama-ui/resolve/latest/dist.tar.gz" \
-				| tar -xzC "${S}/tools/ui/dist"
+				| tar -xzf - -C "${S}/tools/ui/dist"
 		else
 			ln -s "${WORKDIR}/llama-${MY_PV}" "${S}/tools/ui/dist" || die
 		fi


### PR DESCRIPTION
从 #11017 拆分。ebuild 风格与 QA 清理,行为不变。
Split from #11017. Ebuild style and QA cleanups, behavior-preserving.

- treewide: sort variables (S before RESTRICT/IUSE)
- archspec: set EPYTEST_PLUGINS
- cider: relative dosym
- rime-ice: use EGIT_MIN_CLONE_TYPE instead of the git-r3 user variable
- mwparserfromhell: set DISTUTILS_EXT for the C tokenizer (fixes "Python extension modules found installed" QA)
- deepin-wine-helper: place S before RESTRICT
