### PR TITLE
treewide: dependency corrections

### DIFF
--- a/app-emulation/liblol-libxcrypt/liblol-libxcrypt-0.1.10.ebuild
+++ b/app-emulation/liblol-libxcrypt/liblol-libxcrypt-0.1.10.ebuild
@@ -49,11 +49,11 @@ RDEPEND="${DEPEND}
 BDEPEND="
 	dev-lang/perl
 	>=dev-util/patchelf-liblol-0.1.9
-	test? ( $(python_gen_any_dep 'dev-python/passlib[${PYTHON_USEDEP}]') )
+	test? ( $(python_gen_any_dep 'dev-python/libpass[${PYTHON_USEDEP}]') )
 "
 
 python_check_deps() {
-	python_has_version "dev-python/passlib[${PYTHON_USEDEP}]"
+	python_has_version "dev-python/libpass[${PYTHON_USEDEP}]"
 }
 
 pkg_pretend() {

--- a/dev-python/nvchecker/nvchecker-2.21-r1.ebuild
+++ b/dev-python/nvchecker/nvchecker-2.21-r1.ebuild
@@ -18,9 +18,8 @@ IUSE="ini notify"
 RESTRICT="test"
 
 RDEPEND="
-	dev-python/appdirs[$PYTHON_USEDEP]
+	dev-python/platformdirs[$PYTHON_USEDEP]
 	dev-python/structlog[$PYTHON_USEDEP]
-	dev-python/tomli[$PYTHON_USEDEP]
 	>=dev-python/tornado-6[${PYTHON_USEDEP}]
 	ini? (
 		dev-python/iniconfig[$PYTHON_USEDEP]

--- a/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
+++ b/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
@@ -36,7 +36,6 @@ RDEPEND="
 	drm? ( x11-libs/libdrm )
 	opengl? ( virtual/opengl )
 	pcre? ( dev-libs/libpcre )
-	!x11-misc/compton
 	!x11-misc/picom"
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto"

--- a/x11-misc/picom-jonaburg/picom-jonaburg-9999.ebuild
+++ b/x11-misc/picom-jonaburg/picom-jonaburg-9999.ebuild
@@ -29,7 +29,6 @@ RDEPEND="dev-libs/libev
 	drm? ( x11-libs/libdrm )
 	opengl? ( virtual/opengl )
 	pcre? ( dev-libs/libpcre )
-	!x11-misc/compton
 	!x11-misc/picom"
 DEPEND="${RDEPEND}
 	x11-base/xorg-proto"


### PR DESCRIPTION
从 #11017 拆分的依赖正确性修正。

- liblol-libxcrypt:passlib → libpass(::gentoo 已 pkgmove,passlib 被 treeclean)。
- nvchecker:appdirs → platformdirs(源码 import 的就是 platformdirs,原依赖是错的)、去掉 tomli(floor ≥3.11,标准库已有 tomllib);因改的是运行期依赖,revbump 到 -r1。
- picom-jonaburg:去掉已不存在的 `!x11-misc/compton` 阻挡(compton 被 treeclean),保留 `!x11-misc/picom`。

测试:已 rebase 到最新 master;CI 上 nvchecker-2.21-r1、picom-jonaburg emerge 通过;pkgcheck 无新增问题。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
