### PR TITLE
treewide: extend PYTHON_COMPAT to python3_14

### DIFF
--- a/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
+++ b/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://looking-glass.io/artifact/${MY_PV}/source -> ${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="X wayland pipewire pulseaudio +backtrace gnome host obs"
+IUSE="+X wayland +pipewire pulseaudio +backtrace gnome host obs"
 REQUIRED_USE="|| ( X wayland )
 	|| ( pipewire pulseaudio )"
 

--- a/dev-python/adafruit-board-toolkit/adafruit-board-toolkit-1.1.2.ebuild
+++ b/dev-python/adafruit-board-toolkit/adafruit-board-toolkit-1.1.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/exifread/exifread-2.3.1.ebuild
+++ b/dev-python/exifread/exifread-2.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1
 

--- a/dev-python/exifread/exifread-2.3.2.ebuild
+++ b/dev-python/exifread/exifread-2.3.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1
 

--- a/dev-python/exifread/exifread-3.3.2.ebuild
+++ b/dev-python/exifread/exifread-3.3.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1
 

--- a/dev-python/iptcinfo3/iptcinfo3-2.3.0.ebuild
+++ b/dev-python/iptcinfo3/iptcinfo3-2.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{8..13} )
+PYTHON_COMPAT=( python3_{8..14} )
 
 inherit distutils-r1
 

--- a/dev-python/mw2fcitx/mw2fcitx-0.25.1.ebuild
+++ b/dev-python/mw2fcitx/mw2fcitx-0.25.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/nudatus/nudatus-0.0.5.ebuild
+++ b/dev-python/nudatus/nudatus-0.0.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit distutils-r1
 

--- a/dev-python/pypinyin/pypinyin-0.55.0.ebuild
+++ b/dev-python/pypinyin/pypinyin-0.55.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{10..14} pypy3 )
 
 inherit distutils-r1
 

--- a/dev-python/pyrime/pyrime-0.2.3.ebuild
+++ b/dev-python/pyrime/pyrime-0.2.3.ebuild
@@ -34,6 +34,9 @@ RDEPEND="
 BDEPEND="
 	dev-python/autopxd2[${PYTHON_USEDEP}]
 	dev-python/cython[${PYTHON_USEDEP}]
+	test? (
+		dev-python/prompt-toolkit[${PYTHON_USEDEP}]
+	)
 "
 
 EPYTEST_PLUGINS=( )

--- a/games-roguelike/tsl/tsl-0.40-r2.ebuild
+++ b/games-roguelike/tsl/tsl-0.40-r2.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/the-slimy-lichmummy-698f45f25c72f172434fe3ca5fce8e5df7f1e189"
 LICENSE="TSL BSD"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="allegro ncurses"
+IUSE="allegro +ncurses"
 REQUIRED_USE="|| ( allegro ncurses )"
 
 # TSL leverages shell scripts explicitly calling "gcc". We are most displeased.


### PR DESCRIPTION
从 #11017 拆分。PYTHON_COMPAT 加 python3_14 + REQUIRED_USE 默认值(修复 profile 默认 python3_14 下的 RequiredUseDefaults)。
Split from #11017. Extend PYTHON_COMPAT to python3_14 and REQUIRED_USE defaults.

- treewide: extend PYTHON_COMPAT to python3_14 (adafruit, exifread, pypinyin, iptcinfo3, nudatus, mw2fcitx)
  已在 python3.14.6 实测:真实 pip 安装 + import + 运行都通过(pypinyin.lazy_pinyin('中心') 正确输出)。
  Verified on python3.14.6: real pip install + import + exercise all pass.
- tsl: default-enable ncurses; looking-glass: default-enable X and pipewire (satisfy REQUIRED_USE)
- pyrime: add prompt-toolkit as a test dependency
