### PR TITLE
dev-debug/lldb-mi: fix build with CMake 4

### DIFF
--- a/dev-debug/lldb-mi/files/lldb-mi-0.0.1-cmake4.patch
+++ b/dev-debug/lldb-mi/files/lldb-mi-0.0.1-cmake4.patch
@@ -1,0 +1,17 @@
+Bump cmake_minimum_required for CMake 4 compatibility.
+
+CMake 4 dropped compatibility with cmake_minimum_required() versions below
+3.5, so the 0.0.1 tarball (VERSION 3.4.3) can no longer be configured with
+the CMake in the tree. Upstream fixed this on the main branch in PR #120;
+use a range form here so the 0.0.1 release keeps building.
+
+https://github.com/lldb-tools/lldb-mi/pull/120
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4.3)
++cmake_minimum_required(VERSION 3.5...3.20)
+
+ if(POLICY CMP0077)
+   cmake_policy(SET CMP0077 NEW)

--- a/dev-debug/lldb-mi/lldb-mi-0.0.1.ebuild
+++ b/dev-debug/lldb-mi/lldb-mi-0.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Gentoo Authors
+# Copyright 2022-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,3 +20,8 @@ DEPEND="
 	llvm-core/lldb
 "
 RDEPEND="${DEPEND}"
+
+PATCHES=(
+	# CMake 4 no longer accepts cmake_minimum_required < 3.5
+	"${FILESDIR}"/${P}-cmake4.patch
+)


### PR DESCRIPTION
lldb-mi 0.0.1 的 CMakeLists 用 `cmake_minimum_required(VERSION 3.4.3)`,CMake 4 拒绝 <3.5 导致 configure 失败。补 range 补丁 `3.5...3.20`(对应上游 PR #120)。

原 biliup-rs(edition 2024 / Rust 1.85)部分已移除:上游已归档 EOL,已 last-rite(#11107,removal 2026-08-18),不再修。

测试:在 build box 实测 emerge,lldb-mi-0.0.1(连 llvm/lldb 工具链一起)build+install 成功。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
