### PR TITLE
treewide: drop python3_11 from PYTHON_COMPAT (#11037)

### DIFF
--- a/app-backup/snapper-gui/snapper-gui-220626.ebuild
+++ b/app-backup/snapper-gui/snapper-gui-220626.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 COMMIT_ID="191575084a4e951802c32a4177dc704cf435883a"
 inherit distutils-r1
 

--- a/app-dicts/fcitx-pinyin-moegirl/fcitx-pinyin-moegirl-20260315.ebuild
+++ b/app-dicts/fcitx-pinyin-moegirl/fcitx-pinyin-moegirl-20260315.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-any-r1
 
 DESCRIPTION="Fcitx 5 Pinyin Dictionary from zh.moegirl.org.cn"

--- a/app-dicts/fcitx-pinyin-moegirl/fcitx-pinyin-moegirl-20260412.ebuild
+++ b/app-dicts/fcitx-pinyin-moegirl/fcitx-pinyin-moegirl-20260412.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-any-r1
 
 DESCRIPTION="Fcitx 5 Pinyin Dictionary from zh.moegirl.org.cn"

--- a/app-dicts/fcitx-pinyin-moegirl/fcitx-pinyin-moegirl-20260511.ebuild
+++ b/app-dicts/fcitx-pinyin-moegirl/fcitx-pinyin-moegirl-20260511.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-any-r1
 
 DESCRIPTION="Fcitx 5 Pinyin Dictionary from zh.moegirl.org.cn"

--- a/app-dicts/fcitx-pinyin-zhwiki/fcitx-pinyin-zhwiki-0.3.0.20251223.ebuild
+++ b/app-dicts/fcitx-pinyin-zhwiki/fcitx-pinyin-zhwiki-0.3.0.20251223.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-any-r1
 
 MY_PN="fcitx5-pinyin-zhwiki"

--- a/app-dicts/fcitx-pinyin-zhwiki/fcitx-pinyin-zhwiki-0.3.0.20260416.ebuild
+++ b/app-dicts/fcitx-pinyin-zhwiki/fcitx-pinyin-zhwiki-0.3.0.20260416.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-any-r1
 
 MY_PN="fcitx5-pinyin-zhwiki"

--- a/app-editors/flowblade/flowblade-2.24.2.ebuild
+++ b/app-editors/flowblade/flowblade-2.24.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit desktop optfeature python-single-r1 xdg
 

--- a/app-editors/flowblade/flowblade-9999.ebuild
+++ b/app-editors/flowblade/flowblade-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit desktop git-r3 optfeature python-single-r1 xdg
 

--- a/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.45.ebuild
+++ b/app-emulation/deepin-wine-helper/deepin-wine-helper-5.1.45.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..12} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-single-r1 unpacker
 
 DESCRIPTION="Deepin Wine Helper"

--- a/app-emulation/deepin-wine-plugin/deepin-wine-plugin-5.1.13-r1.ebuild
+++ b/app-emulation/deepin-wine-plugin/deepin-wine-plugin-5.1.13-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..12} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit unpacker python-r1
 
 DESCRIPTION="Deepin Wine plugin"

--- a/app-emulation/liblol-glibc/liblol-glibc-0.1.10-r1.ebuild
+++ b/app-emulation/liblol-glibc/liblol-glibc-0.1.10-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=8
 # Bumping notes: https://wiki.gentoo.org/wiki/Project:Toolchain/sys-libs/glibc
 # Please read & adapt the page as necessary if obsolete.
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 TMPFILES_OPTIONAL=1
 
 EMULTILIB_PKG="true"

--- a/app-emulation/liblol-libxcrypt/liblol-libxcrypt-0.1.10.ebuild
+++ b/app-emulation/liblol-libxcrypt/liblol-libxcrypt-0.1.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 # NEED_BOOTSTRAP is for developers to quickly generate a tarball
 # for publishing to the tree.
 NEED_BOOTSTRAP="no"

--- a/dev-python/archspec/archspec-0.2.6.ebuild
+++ b/dev-python/archspec/archspec-0.2.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/autopxd2/autopxd2-3.2.3.ebuild
+++ b/dev-python/autopxd2/autopxd2-3.2.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 PYPI_VERIFY_REPO="https://github.com/elijahr/python-autopxd2"
 inherit distutils-r1 pypi

--- a/dev-python/conda-libmamba-solver/conda-libmamba-solver-26.6.0.ebuild
+++ b/dev-python/conda-libmamba-solver/conda-libmamba-solver-26.6.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1
 
 DESCRIPTION="The libmamba based solver for conda"

--- a/dev-python/conda-libmamba-solver/conda-libmamba-solver-26.7.0.ebuild
+++ b/dev-python/conda-libmamba-solver/conda-libmamba-solver-26.7.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1
 
 DESCRIPTION="The libmamba based solver for conda"

--- a/dev-python/daff/daff-1.4.2.ebuild
+++ b/dev-python/daff/daff-1.4.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..13} pypy3 )
+PYTHON_COMPAT=( python3_{12..14} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/exifread/exifread-3.5.1.ebuild
+++ b/dev-python/exifread/exifread-3.5.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/feeluown-bilibili/feeluown-bilibili-0.4.1.ebuild
+++ b/dev-python/feeluown-bilibili/feeluown-bilibili-0.4.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 PYPI_NO_NORMALIZE=true
 inherit distutils-r1 pypi
 

--- a/dev-python/feeluown-bilibili/feeluown-bilibili-0.5.5.ebuild
+++ b/dev-python/feeluown-bilibili/feeluown-bilibili-0.5.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="bilibili support for feeluown"

--- a/dev-python/frozendict/frozendict-2.4.7.ebuild
+++ b/dev-python/frozendict/frozendict-2.4.7.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1
 
 DESCRIPTION="A simple immutable dictionary for Python"

--- a/dev-python/fuo-netease/fuo-netease-1.0.3.ebuild
+++ b/dev-python/fuo-netease/fuo-netease-1.0.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} pypy)
+PYTHON_COMPAT=( python3_{12..14} pypy)
 
 inherit distutils-r1 pypi
 

--- a/dev-python/fuo-netease/fuo-netease-1.0.8.ebuild
+++ b/dev-python/fuo-netease/fuo-netease-1.0.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} pypy)
+PYTHON_COMPAT=( python3_{12..14} pypy)
 
 inherit distutils-r1 pypi
 

--- a/dev-python/fuo-qqmusic/fuo-qqmusic-1.0.16.ebuild
+++ b/dev-python/fuo-qqmusic/fuo-qqmusic-1.0.16.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} pypy)
+PYTHON_COMPAT=( python3_{12..14} pypy)
 
 inherit distutils-r1 pypi
 

--- a/dev-python/fuo-qqmusic/fuo-qqmusic-1.0.5.ebuild
+++ b/dev-python/fuo-qqmusic/fuo-qqmusic-1.0.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} pypy)
+PYTHON_COMPAT=( python3_{12..14} pypy)
 
 inherit distutils-r1 pypi
 

--- a/dev-python/janus/janus-2.0.0.ebuild
+++ b/dev-python/janus/janus-2.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} pypy3 )
+PYTHON_COMPAT=( python3_{12..14} pypy3 )
 PYPI_VERIFY_REPO=https://github.com/aio-libs/janus
 
 inherit distutils-r1 pypi

--- a/dev-python/jieba/jieba-0.42.1.ebuild
+++ b/dev-python/jieba/jieba-0.42.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 pypi
 

--- a/dev-python/menuinst/menuinst-2.5.2.ebuild
+++ b/dev-python/menuinst/menuinst-2.5.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1
 
 DESCRIPTION="Cross platform menu item installation"

--- a/dev-python/microfs2/microfs2-2.1.1.ebuild
+++ b/dev-python/microfs2/microfs2-2.1.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} pypy3 )
+PYTHON_COMPAT=( python3_{12..14} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/microrepl/microrepl-0.6.ebuild
+++ b/dev-python/microrepl/microrepl-0.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} pypy3 )
+PYTHON_COMPAT=( python3_{12..14} pypy3 )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
+++ b/dev-python/mwparserfromhell/mwparserfromhell-0.7.2.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_EXT=1
-PYTHON_COMPAT=( python3_{11..15} )
+PYTHON_COMPAT=( python3_{12..15} )
 
 inherit distutils-r1
 

--- a/dev-python/nvchecker/nvchecker-2.21.ebuild
+++ b/dev-python/nvchecker/nvchecker-2.21.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1
 
 DESCRIPTION="nvchecker is for checking if a new version of some software has been released"

--- a/dev-python/pycosat/pycosat-0.6.6.ebuild
+++ b/dev-python/pycosat/pycosat-0.6.6.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1
 
 DESCRIPTION="Python bindings to picosat (a SAT solver)"

--- a/dev-python/pyqt6-charts/pyqt6-charts-6.11.0.ebuild
+++ b/dev-python/pyqt6-charts/pyqt6-charts-6.11.0.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=sip
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1 flag-o-matic multiprocessing pypi qmake-utils
 
 QT_PV=$(ver_cut 1-2):6

--- a/dev-python/pyrime/pyrime-0.2.3.ebuild
+++ b/dev-python/pyrime/pyrime-0.2.3.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_EXT=1
 DISTUTILS_USE_PEP517=meson-python
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit distutils-r1 pypi
 
 DESCRIPTION="rime for python"

--- a/dev-python/pywikibot/pywikibot-10.3.0.ebuild
+++ b/dev-python/pywikibot/pywikibot-10.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit pypi distutils-r1
 

--- a/dev-python/pywikibot/pywikibot-10.7.4.ebuild
+++ b/dev-python/pywikibot/pywikibot-10.7.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit pypi distutils-r1
 

--- a/dev-python/qasync/qasync-0.28.0.ebuild
+++ b/dev-python/qasync/qasync-0.28.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{10..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/sounddevice/sounddevice-0.5.5.ebuild
+++ b/dev-python/sounddevice/sounddevice-0.5.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 PYPI_VERIFY_REPO="https://github.com/spatialaudio/python-sounddevice"
 inherit distutils-r1 pypi

--- a/dev-python/soxr/soxr-1.0.0.ebuild
+++ b/dev-python/soxr/soxr-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=scikit-build-core
 DISTUTILS_EXT=1
 PYPI_VERIFY_REPO="https://github.com/dofuuz/python-soxr"

--- a/dev-util/mamba/mamba-2.5.0.ebuild
+++ b/dev-util/mamba/mamba-2.5.0.ebuild
@@ -7,7 +7,7 @@ DISTUTILS_USE_PEP517=scikit-build-core
 DISTUTILS_EXT=1
 DISTUTILS_OPTIONAL=1
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=(python3_{11..14})
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1 cmake multilib
 

--- a/games-fps/source-engine/source-engine-9999.ebuild
+++ b/games-fps/source-engine/source-engine-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_11 python3_12 )
+PYTHON_COMPAT=( python3_{12..14} )
 PYTHON_REQ_USE='threads(+)'
 
 inherit waf-utils git-r3 python-any-r1

--- a/media-plugins/osdlyrics/osdlyrics-0.5.15.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-0.5.15.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit python-r1 autotools optfeature xdg
 

--- a/media-plugins/osdlyrics/osdlyrics-9999.ebuild
+++ b/media-plugins/osdlyrics/osdlyrics-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit python-r1 autotools optfeature xdg
 

--- a/sys-apps/wait-online/wait-online-9999.ebuild
+++ b/sys-apps/wait-online/wait-online-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit git-r3 systemd python-r1
 

--- a/sys-libs/libsolv/libsolv-0.7.39.ebuild
+++ b/sys-libs/libsolv/libsolv-0.7.39.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{8..15} )
+PYTHON_COMPAT=( python3_{12..15} )
 
 inherit cmake python-single-r1
 

--- a/sys-power/tlpui/tlpui-1.10.1.ebuild
+++ b/sys-power/tlpui/tlpui-1.10.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_SINGLE_IMPL=y
 inherit distutils-r1 desktop xdg-utils
 

--- a/www-servers/woof/woof-9999.ebuild
+++ b/www-servers/woof/woof-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit git-r3 python-single-r1
 

--- a/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
+++ b/x11-misc/picom-jonaburg/picom-jonaburg-8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{9..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit meson python-any-r1 virtualx xdg
 
 DESCRIPTION="jonaburg's picom fork with dual_kawase blur and rounded corners"

--- a/x11-themes/mint-themes/mint-themes-2.4.0.ebuild
+++ b/x11-themes/mint-themes/mint-themes-2.4.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{12..14} )
 inherit python-any-r1
 
 DESCRIPTION="A collection of Linux Mint themes"


### PR DESCRIPTION
处理 #11037,并清掉全 overlay 残留的 python3_11(dev-python/requests 上游已砍 3.11,带着它会解析失败)。

做法:所有还允许 python3_11 的包 floor 抬到 python3_12,并确保 profile 默认的 python3_14 在范围内(原封顶 3_13 的补到 3_14)。python3_15 不主动加——本机无 3.15 无法验证,C 扩展尤甚;唯一例外 mwparserfromhell {12..15}(3.15 已 build+test 验证)。

已 rebase 到最新 master(与已合并的 #11048 重叠的几行自动落定,现 50 个包)。

测试:pkgcheck 无 RequiredUseDefaults;纯 Python 那批在 python3.14 实测 pip 装+import;CI build gate 通过。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
