### PR TITLE
treewide: set PYTHON_COMPAT to python3_{12..14}

### DIFF
--- a/dev-python/adafruit-board-toolkit/adafruit-board-toolkit-1.1.2.ebuild
+++ b/dev-python/adafruit-board-toolkit/adafruit-board-toolkit-1.1.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1 pypi
 

--- a/dev-python/exifread/exifread-2.3.1.ebuild
+++ b/dev-python/exifread/exifread-2.3.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/exifread/exifread-2.3.2.ebuild
+++ b/dev-python/exifread/exifread-2.3.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/exifread/exifread-3.3.2.ebuild
+++ b/dev-python/exifread/exifread-3.3.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/iptcinfo3/iptcinfo3-2.3.0.ebuild
+++ b/dev-python/iptcinfo3/iptcinfo3-2.3.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=hatchling
-PYTHON_COMPAT=( python3_{8..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/mw2fcitx/mw2fcitx-0.25.1.ebuild
+++ b/dev-python/mw2fcitx/mw2fcitx-0.25.1.ebuild
@@ -5,7 +5,7 @@ EAPI=8
 
 DISTUTILS_USE_PEP517=poetry
 DISTUTILS_SINGLE_IMPL=1
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 PYPI_VERIFY_REPO=https://github.com/outloudvi/mw2fcitx
 
 inherit distutils-r1 pypi

--- a/dev-python/nudatus/nudatus-0.0.5.ebuild
+++ b/dev-python/nudatus/nudatus-0.0.5.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 
 inherit distutils-r1
 

--- a/dev-python/pypinyin/pypinyin-0.55.0.ebuild
+++ b/dev-python/pypinyin/pypinyin-0.55.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..13} pypy3 )
+PYTHON_COMPAT=( python3_{12..14} pypy3 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
从 #11048 拆出的纯 python-compat 部分(6 个纯 Python 包,已在 python3.14 实测 import 通过)。
Pure python-compat part split from #11048 (6 pure-python packages, verified importing on python3.14).