### PR TITLE
treewide: fix REQUIRED_USE defaults and a missing test dep

### DIFF
--- a/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
+++ b/app-emulation/looking-glass/looking-glass-0_beta7_rc1-r2.ebuild
@@ -15,7 +15,7 @@ SRC_URI="https://looking-glass.io/artifact/${MY_PV}/source -> ${P}.tar.gz"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="X wayland pipewire pulseaudio +backtrace gnome host obs"
+IUSE="+X wayland +pipewire pulseaudio +backtrace gnome host obs"
 REQUIRED_USE="|| ( X wayland )
 	|| ( pipewire pulseaudio )"
 

--- a/dev-python/pyrime/pyrime-0.2.3.ebuild
+++ b/dev-python/pyrime/pyrime-0.2.3.ebuild
@@ -34,6 +34,9 @@ RDEPEND="
 BDEPEND="
 	dev-python/autopxd2[${PYTHON_USEDEP}]
 	dev-python/cython[${PYTHON_USEDEP}]
+	test? (
+		dev-python/prompt-toolkit[${PYTHON_USEDEP}]
+	)
 "
 
 EPYTEST_PLUGINS=( )

--- a/games-roguelike/tsl/tsl-0.40-r2.ebuild
+++ b/games-roguelike/tsl/tsl-0.40-r2.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}/the-slimy-lichmummy-698f45f25c72f172434fe3ca5fce8e5df7f1e189"
 LICENSE="TSL BSD"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="allegro ncurses"
+IUSE="allegro +ncurses"
 REQUIRED_USE="|| ( allegro ncurses )"
 
 # TSL leverages shell scripts explicitly calling "gcc". We are most displeased.


### PR DESCRIPTION
从 #11048 拆出的 REQUIRED_USE / 测试依赖修正。

原因:looking-glass、tsl 在 profile 默认 USE 下,REQUIRED_USE 的 `|| ( )` 组一个都没默认开,fresh emerge 会直接 REQUIRED_USE 失败装不上;pyrime 测试阶段缺 prompt-toolkit。

改动:looking-glass 默认开 X、pipewire;tsl 默认开 ncurses;pyrime 补 `test? ( dev-python/prompt-toolkit )`。

测试:CI 实测 looking-glass build+install、pyrime build+test 通过。tsl 的编译红是上游 GCC-15/C23 既有 bug(改前也红,与本改无关)。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
