### PR TITLE
treewide: follow upstream repo/SRC_URI renames (verified)

### DIFF
--- a/app-i18n/ibus-rime/ibus-rime-9999.ebuild
+++ b/app-i18n/ibus-rime/ibus-rime-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,8 +6,8 @@ EAPI=7
 inherit git-r3
 
 DESCRIPTION="Rime Input Method Engine for IBus Framework"
-HOMEPAGE="http://code.google.com/p/rimeime/"
-EGIT_REPO_URI="https://github.com/lotem/${PN}.git"
+HOMEPAGE="https://rime.im/ https://github.com/rime/ibus-rime"
+EGIT_REPO_URI="https://github.com/rime/${PN}.git"
 
 LICENSE="GPL-3"
 SLOT="0"

--- a/games-fps/openarena-bin/openarena-bin-0.8.8.ebuild
+++ b/games-fps/openarena-bin/openarena-bin-0.8.8.ebuild
@@ -2,10 +2,10 @@ EAPI=8
 inherit desktop
 
 DESCRIPTION="A violent, sexy, multiplayer first person shooter based on the ioquake3 engine"
-HOMEPAGE="http://openarena.ws https://en.wikipedia.org/wiki/OpenArena"
+HOMEPAGE="https://openarena.ws https://en.wikipedia.org/wiki/OpenArena"
 
 SRC_URI="
-	https://psychz.dl.sourceforge.net/project/oarena/openarena-${PV}.zip?viasf=1 -> openarena-${PV}.zip
+	https://downloads.sourceforge.net/oarena/openarena-${PV}.zip
 	https://upload.wikimedia.org/wikipedia/commons/2/2c/Openarena.png
 	https://upload.wikimedia.org/wikipedia/commons/7/7b/Openarena-server.png
 "

--- a/games-fps/openarena/openarena-0.8.8.ebuild
+++ b/games-fps/openarena/openarena-0.8.8.ebuild
@@ -2,9 +2,9 @@ EAPI=8
 inherit desktop unpacker
 
 DESCRIPTION="A violent, sexy, multiplayer first person shooter based on the ioquake3 engine"
-HOMEPAGE="http://openarena.ws https://en.wikipedia.org/wiki/OpenArena"
+HOMEPAGE="https://openarena.ws https://en.wikipedia.org/wiki/OpenArena"
 SRC_URI="
-	https://psychz.dl.sourceforge.net/project/oarena/${P}.zip?viasf=1 -> ${P}.zip
+	https://downloads.sourceforge.net/oarena/${P}.zip
 	https://github.com/OpenArena/legacy/archive/3db79b091ce1d950d9cdcac0445a2134f49a6fc7.tar.gz -> ${P}-engine.tar.gz
 	https://upload.wikimedia.org/wikipedia/commons/2/2c/Openarena.png
 	https://upload.wikimedia.org/wikipedia/commons/7/7b/Openarena-server.png

--- a/games-fps/openarena/openarena-9999.ebuild
+++ b/games-fps/openarena/openarena-9999.ebuild
@@ -2,9 +2,9 @@ EAPI=8
 inherit desktop unpacker
 
 DESCRIPTION="A violent, sexy, multiplayer first person shooter based on the ioquake3 engine"
-HOMEPAGE="http://openarena.ws https://en.wikipedia.org/wiki/OpenArena"
+HOMEPAGE="https://openarena.ws https://en.wikipedia.org/wiki/OpenArena"
 SRC_URI="
-	https://psychz.dl.sourceforge.net/project/oarena/openarena-0.8.8.zip?viasf=1 -> openarena-0.8.8.zip
+	https://downloads.sourceforge.net/oarena/openarena-0.8.8.zip
 	https://upload.wikimedia.org/wikipedia/commons/2/2c/Openarena.png
 	https://upload.wikimedia.org/wikipedia/commons/7/7b/Openarena-server.png
 "

--- a/media-fonts/ttf-wps-fonts/ttf-wps-fonts-9999.ebuild
+++ b/media-fonts/ttf-wps-fonts/ttf-wps-fonts-9999.ebuild
@@ -6,12 +6,12 @@ DISABLE_AUTOFORMATTING=true
 inherit font unpacker git-r3
 
 DESCRIPTION="Symbol fonts required by wps-office"
-HOMEPAGE="https://github.com/iamdh4/ttf-wps-fonts"
+HOMEPAGE="https://github.com/dv-anomaly/ttf-wps-fonts"
 
 LICENSE="all-rights-reserved"
 SLOT="0"
 
-EGIT_REPO_URI="https://github.com/iamdh4/ttf-wps-fonts.git"
+EGIT_REPO_URI="https://github.com/dv-anomaly/ttf-wps-fonts.git"
 
 FONT_SUFFIX="ttf"
 

--- a/x11-misc/i3lock-color/i3lock-color-9999.ebuild
+++ b/x11-misc/i3lock-color/i3lock-color-9999.ebuild
@@ -6,8 +6,8 @@ EAPI=8
 inherit git-r3 autotools
 
 DESCRIPTION="An improved i3lock"
-HOMEPAGE="https://github.com/chrjguill/i3lock-color"
-EGIT_REPO_URI="https://github.com/chrjguill/i3lock-color.git"
+HOMEPAGE="https://github.com/Raymo111/i3lock-color"
+EGIT_REPO_URI="https://github.com/Raymo111/i3lock-color.git"
 LICENSE="BSD"
 
 SLOT="0"


### PR DESCRIPTION
Split out of the metadata-hygiene work: SRC_URI / repo-URI changes that track
upstream org/repo renames.

**Live-EGIT (repo moved; verified the new repo is the canonical/maintained one):**
- `app-i18n/ibus-rime`: `lotem` → `rime` org (rime.im canonical)
- `x11-misc/i3lock-color`: `chrjguill` → `Raymo111` (maintained fork)
- `media-fonts/ttf-wps-fonts`: `iamdh4` → `dv-anomaly`

**SourceForge mirror:**
- `games-fps/openarena{,-bin}`: pinned host `psychz.dl.sourceforge.net` → canonical
  `downloads.sourceforge.net` (resolves, Content-Length 425189255 = Manifest; hash unchanged)

The cargo git-dep renames (codex/rules_rust, clash-rs/quinn-congestions,
waylyrics/dark-light) were **dropped**: those URLs key cargo's offline source
replacement and must match upstream `Cargo.lock`, so renaming them breaks the
build. Upstream's GitHub repo-rename redirects keep the original URLs fetching
fine, so master already builds them correctly.

HOMEPAGE updates that follow the same upstream move are folded into each commit.