### PR TITLE
app-i18n/rime-ice: use EGIT_CLONE_TYPE instead of EGIT_MIN_CLONE_TYPE

### DIFF
--- a/app-i18n/rime-ice/rime-ice-9999.ebuild
+++ b/app-i18n/rime-ice/rime-ice-9999.ebuild
@@ -12,7 +12,7 @@ EGIT_REPO_URI="https://github.com/iDvel/rime-ice.git"
 # === Optimization: Shallow Clone ===
 # Force shallow clone (depth=1) to save bandwidth and disk space.
 # This repo contains heavy git history which is unnecessary for deployment.
-EGIT_MIN_CLONE_TYPE="shallow"
+EGIT_CLONE_TYPE="shallow"
 
 LICENSE="GPL-3"
 SLOT="0"


### PR DESCRIPTION
回退来自 #11046 的修改。
使用 EGIT_MIN_CLONE_TYPE 替代 EGIT_CLONE_TYPE 是误用。

#11072 提到要回退此修改但是没有成功回退。

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
