### PR TITLE
x11-terms/wezterm-bin: update HOMEPAGE

### DIFF
--- a/x11-terms/wezterm-bin/wezterm-bin-20240203.ebuild
+++ b/x11-terms/wezterm-bin/wezterm-bin-20240203.ebuild
@@ -11,7 +11,7 @@ MY_PN="${PN/-bin/}"
 MY_P="${MY_PN}-${MY_PV}"
 
 DESCRIPTION="A terminal emulator and multiplexer implemented in Rust"
-HOMEPAGE="https://wezfurlong.org/wezterm/"
+HOMEPAGE="https://github.com/wezterm/wezterm https://wezterm.org"
 
 SRC_URI="https://github.com/wezterm/wezterm/releases/download/${MY_PV}/${MY_PN}-${MY_PV}.Ubuntu20.04.tar.xz"
 


### PR DESCRIPTION
上游从 wezfurlong.org 搬到 wezterm.org 与 github.com/wezterm/wezterm,更新 HOMEPAGE。纯 metadata 改动,不 revbump。
