### PR TITLE
media-libs/openslide: fix build if installed dev-util/xdelta

### DIFF
--- a/media-libs/openslide/openslide-4.0.1.ebuild
+++ b/media-libs/openslide/openslide-4.0.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -13,6 +13,9 @@ LICENSE="LGPL-2.1"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~loong"
 
+IUSE="doc"
+RESTRICT="test"
+
 RDEPEND="
 	virtual/zlib
 	app-arch/zstd
@@ -26,5 +29,15 @@ RDEPEND="
 	dev-libs/libxml2
 	dev-db/sqlite:3
 	media-libs/libdicom
+	doc? ( app-text/doxygen )
 "
 DEPEND="${RDEPEND}"
+
+src_configure() {
+	# Disable test, its requires download big test resource from the Internet.
+	local emesonargs=(
+		-Dtest=disabled
+		$(meson_feature doc)
+	)
+	meson_src_configure
+}


### PR DESCRIPTION
Fixes: #11099

系统中安装了 dev-util/xdelta 会满足测试的环境需求并自动开启测试，
此软件的测试需要在线下载资源文件，尝试下载时会被 network-sandbox 阻挡。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
