### PR TITLE
profiles: mask net-misc/biliup-rs for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -41,3 +41,10 @@ app-misc/ccal
 # no remaining target to protect
 # Removal on 2026-08-13
 sec-policy/apparmor-profile-deepinwine
+
+# Zakk <zakk@gentoozh.org> (2026-07-18)
+# Upstream is archived and EOL; it directs users to biliup/biliup. We plan to
+# follow the upstream migration to biliup/biliup, which is not yet packaged
+# here.
+# Masked for removal in 2026-08-18
+net-misc/biliup-rs


### PR DESCRIPTION
biliup-rs 上游已归档并明确 EOL,官方指引改用 https://github.com/biliup/biliup。 我们计划跟随上游迁移到 biliup/biliup;故先 last-rite,removal 定在 2026-08-18。 這剛好是biliup-rs 最後一次更新的一年時間

测试:`pkgcheck scan --commits --net` 干净。

属 #10971 的 biliup-rs 部分。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
