### PR TITLE
app-text/groff-utf8: fix pkg_postinst on man-db systems

### DIFF
--- a/app-text/groff-utf8/groff-utf8-0-r2.ebuild
+++ b/app-text/groff-utf8/groff-utf8-0-r2.ebuild
@@ -28,9 +28,10 @@ src_install() {
 }
 
 pkg_postinst() {
-	sed	's/^NROFF.*\/usr\/bin\/nroff -mandoc/NROFF\t\t\/usr\/bin\/groff-utf8 -Tutf8 -c -mandoc/' -i /etc/man.conf || die
-}
-
-pkg_postrm(){
-	sed	's/groff-utf8 -Tutf8 -c -mandoc/nroff -mandoc/g' -i /etc/man.conf || die
+	elog "man-db renders UTF-8 man pages itself (via preconv) in a UTF-8"
+	elog "locale, so this wrapper is normally not required. To route man"
+	elog "through groff-utf8 anyway, change the nroff definition in"
+	elog "/etc/man_db.conf to:"
+	elog
+	elog "    DEFINE nroff groff-utf8 -Tutf8 -c -mandoc"
 }


### PR DESCRIPTION
groff-utf8-0-r1 的 pkg_postinst 用 sed 改 /etc/man.conf 并 || die。该文件属于早已移除的 sys-apps/man;现在是 sys-apps/man-db(配置 /etc/man_db.conf、格式不同),文件不存在 → sed 失败 die,merge 中止。

man-db 在 UTF-8 locale 下自己就用 preconv 渲染,不需要硬改;所以不再去动别的包的配置文件,改成 elog 提示要启用的人怎么在 /etc/man_db.conf 里改 nroff 定义,并去掉对应的 pkg_postrm。revbump 到 -r2。

测试:`pkgcheck scan --commits --net` 干净;本机 `ebuild install` 编译安装通过;`pkg_postinst` 实跑只出 elog、退出 0(不再 die)。

Closes #11039

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
