### PR TITLE
games-fps/openarena-bin: move runtime deps to RDEPEND, restrict KEYWORDS

### DIFF
--- a/games-fps/openarena-bin/openarena-bin-0.8.8-r1.ebuild
+++ b/games-fps/openarena-bin/openarena-bin-0.8.8-r1.ebuild
@@ -16,12 +16,11 @@ LICENSE="GPL-3"
 
 SLOT="0"
 
-KEYWORDS="~amd64 ~x86"
+KEYWORDS="-* ~amd64 ~x86"
 
 BDEPEND="app-arch/unzip"
 
-DEPEND="
-	${COMMON_DEPENDS}
+RDEPEND="
 	media-libs/libvorbis
 	net-misc/curl
 	media-libs/openal


### PR DESCRIPTION
openarena-bin 是预编译包,执行期共享库(libsdl/openal/libvorbis/curl/libxmp)原本放在 DEPEND,应在 RDEPEND——原 ebuild 根本没有 RDEPEND,运行期不保证拉进来。一并把 KEYWORDS 补 `-*`(预编译、限架构),删掉未定义的 `${COMMON_DEPENDS}`。因改动运行期依赖,revbump 到 -r1。

测试:`pkgcheck scan --commits --net` 干净。#11041 里「32 位 binary 的 unresolved-soname 会让 CI 变红」经实测不成立——CI 用的 amd64-desktop 映像是 ABI_X86=64(非 multilib),portage 跳过外来 ABI 的 32 位 binary,build 干净无 elog;故本 PR 不碰 soname,只修上述真实小 QA。

Closes #11041

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
