### PR TITLE
games-fps/source-engine: drop obsolete waf -8 option

### DIFF
--- a/games-fps/source-engine/source-engine-9999.ebuild
+++ b/games-fps/source-engine/source-engine-9999.ebuild
@@ -27,7 +27,6 @@ BDEPEND="${PYTHON_DEPS}
 
 src_configure() {
 	local conf=(
-		'-8'
 		$(usex debug '-T debug' '-T release')
 	)
 	waf-utils_src_configure "${conf[@]}"


### PR DESCRIPTION
source-engine-9999(live)的 src_configure 传了 `-8` 给 waf,但上游 wscript 已经没有这个选项(架构改用 `-4`/`--32bits`,64 位是默认),导致 configure 直接 `waf: error: no such option: -8` 失败。去掉 `-8` 即可,默认就是要的 64 位。

测试:在 build box 实测 emerge——去掉 `-8` 后 source-engine-9999 完整 build+install 成功。

(发现于验证 #11051 的 python3.14 兼容性时:python3.14 本身没问题,卡在这个 waf 选项。)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
