### PR TITLE
profiles: mask sys-kernel/cachyos-sources for security

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,3 +1,10 @@
+# Zakk <zakk@gentoozh.org> (2026-07-18)
+# Outdated kernel: it does not carry the Copy Fail and Dirty Flag fixes and
+# has not been bumped for a long time. Masked for security until a newer
+# version is added.
+# https://github.com/gentoo-zh/overlay/issues/11122
+<=sys-kernel/cachyos-sources-6.18.6
+
 # jinqiang zhang <peeweep@0x0.ee> (2026-07-14)
 # Looks like no one use this package for a long time
 # Masked for removal in 2026-08-14


### PR DESCRIPTION
cachyos-sources-6.18.6 缺 Copy Fail / Dirty Flag 修复,且长期未 bump。出于安全考虑先 mask,等有更新版本再解除。用 `<=` 让将来的 bump 自动不受 mask。
#11122

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
