### PR TITLE
nvchecker: cachyos-sources: track CachyOS/linux instead of personal repo

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2215,9 +2215,11 @@ github_account = "gouwazi"
 
 ["sys-kernel/cachyos-sources"]
 source = "github"
-github = "blackteahamburger/gentoo-CachyOS-kernel-patches-tarball"
+github = "CachyOS/linux"
 use_latest_release = true
-github_account = "blackteahamburger"
+from_pattern = "cachyos-([0-9.]+)-[0-9]+"
+to_pattern = "\\1"
+github_account = ["blackteahamburger", "Zakkaus"]
 
 ["sys-kernel/liquorix-sources"]
 source = "github"


### PR DESCRIPTION
cachyos-sources 的 nvchecker 源原本是个人 repo `blackteahamburger/gentoo-CachyOS-kernel-patches-tarball`,半年没更新、停在 6.18.6,所以 bump 提示一直指向已在 tree 的旧版本。

改成抓官方 `CachyOS/linux` 的 release(tag `cachyos-<ver>-<rel>`,用 from/to_pattern 抽出版本),反映真实当前 CachyOS 内核(现 7.1.4)。并把 Zakkaus 加进 CC。

注:补丁 distfile 目前仍来自那个个人 repo(ebuild 的 `CACHYOS_URI`),所以提示到 7.1.4 后要真 bump,还需该 tarball(或另换补丁源)跟上。本 PR 只修 nvchecker 提示,不动 ebuild。

Closes #11124

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
