### PR TITLE
.github/workflows/overlay.toml: stop tracking xanmod-kernel (dup of xanmod-sources)

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2236,12 +2236,14 @@ gitlab = "archlinux/mkinitcpio/mkinitcpio"
 use_max_tag = true
 prefix = "v"
 
-["sys-kernel/xanmod-kernel"]
-source = "gitlab"
-gitlab = "xanmod/linux"
-use_max_tag = true
-from_pattern = "(.*)-xanmod(.*)"
-to_pattern = "\\1"
+# xanmod-kernel and xanmod-sources track the same repo (xanmod/linux) and are
+# always bumped together, so track only the source xanmod-sources.
+# ["sys-kernel/xanmod-kernel"]
+# source = "gitlab"
+# gitlab = "xanmod/linux"
+# use_max_tag = true
+# from_pattern = "(.*)-xanmod(.*)"
+# to_pattern = "\\1"
 
 #["sys-kernel/xanmod-rt"]
 


### PR DESCRIPTION
xanmod-kernel 与 xanmod-sources 是同一上游(gitlab `xanmod/linux`、同一 tag),版本一向锁步——git log 里一直是 `sys-kernel/xanmod-{kernel, sources}: bump to X` 同一 commit 一起 bump。两条 nvchecker 各为一个包发 bump issue,就重复了(#11120 与 #11121 都指同一个 7.1.4)。遮蔽结论见 #11128。

只保留 xanmod-sources 追踪当作「新 xanmod 出了」的信号,注释掉 xanmod-kernel,之后每次发版只有一个 issue,bump 时照旧 kernel + sources 一起改。xanmod-rt 走 RT 发布线、版本不同步,本就已注释、不受影响。

只改 nvchecker 追踪、不动 ebuild;7.1.4 的实际 bump 仍待办(见 #11121)。

Closes #11120

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
