### PR TITLE
app-text/wiki2man_on_rust: fix depend-phase sandbox violation

### DIFF
--- a/app-text/wiki2man_on_rust/wiki2man_on_rust-0.1.10-r1.ebuild
+++ b/app-text/wiki2man_on_rust/wiki2man_on_rust-0.1.10-r1.ebuild
@@ -114,13 +114,17 @@ DUMP_CHUNKS=(
 	"ja:jawiki:p2410004p5212524"
 )
 
+# Split with parameter expansion, not `read <<<`: a here-string needs a temp
+# file in ${PWD}, and the depend (metadata) phase can run with an unwritable
+# CWD, which trips the sandbox.
 for wiki in "${WIKIS[@]}"; do
-	IFS=":" read -r l10n_code _ <<< "${wiki}"
-	IUSE+=" l10n_${l10n_code}"
+	IUSE+=" l10n_${wiki%%:*}"
 done
 
 for dump in "${DUMP_CHUNKS[@]}"; do
-	IFS=":" read -r l10n_code wiki_id chunk <<< "${dump}"
+	l10n_code="${dump%%:*}"
+	wiki_id="${dump#*:}"; wiki_id="${wiki_id%%:*}"
+	chunk="${dump##*:}"
 	SRC_URI+=" l10n_${l10n_code}? ( ${DUMP_BASE_URL}/${wiki_id}/${DUMP_DATE}/xml/bzip2/${wiki_id}-${DUMP_DATE}-${chunk}.xml.bz2 )"
 done
 

--- a/app-text/wiki2man_on_rust/wiki2man_on_rust-0.2.1-r1.ebuild
+++ b/app-text/wiki2man_on_rust/wiki2man_on_rust-0.2.1-r1.ebuild
@@ -114,13 +114,17 @@ DUMP_CHUNKS=(
 	"ja:jawiki:p2410004p5212524"
 )
 
+# Split with parameter expansion, not `read <<<`: a here-string needs a temp
+# file in ${PWD}, and the depend (metadata) phase can run with an unwritable
+# CWD, which trips the sandbox.
 for wiki in "${WIKIS[@]}"; do
-	IFS=":" read -r l10n_code _ <<< "${wiki}"
-	IUSE+=" l10n_${l10n_code}"
+	IUSE+=" l10n_${wiki%%:*}"
 done
 
 for dump in "${DUMP_CHUNKS[@]}"; do
-	IFS=":" read -r l10n_code wiki_id chunk <<< "${dump}"
+	l10n_code="${dump%%:*}"
+	wiki_id="${dump#*:}"; wiki_id="${wiki_id%%:*}"
+	chunk="${dump##*:}"
 	SRC_URI+=" l10n_${l10n_code}? ( ${DUMP_BASE_URL}/${wiki_id}/${DUMP_DATE}/xml/bzip2/${wiki_id}-${DUMP_DATE}-${chunk}.xml.bz2 )"
 done
 

--- a/app-text/wiki2man_on_rust/wiki2man_on_rust-0.5.1-r1.ebuild
+++ b/app-text/wiki2man_on_rust/wiki2man_on_rust-0.5.1-r1.ebuild
@@ -114,13 +114,17 @@ DUMP_CHUNKS=(
 	"ja:jawiki:p2410004p5212524"
 )
 
+# Split with parameter expansion, not `read <<<`: a here-string needs a temp
+# file in ${PWD}, and the depend (metadata) phase can run with an unwritable
+# CWD, which trips the sandbox.
 for wiki in "${WIKIS[@]}"; do
-	IFS=":" read -r l10n_code _ <<< "${wiki}"
-	IUSE+=" l10n_${l10n_code}"
+	IUSE+=" l10n_${wiki%%:*}"
 done
 
 for dump in "${DUMP_CHUNKS[@]}"; do
-	IFS=":" read -r l10n_code wiki_id chunk <<< "${dump}"
+	l10n_code="${dump%%:*}"
+	wiki_id="${dump#*:}"; wiki_id="${wiki_id%%:*}"
+	chunk="${dump##*:}"
 	SRC_URI+=" l10n_${l10n_code}? ( ${DUMP_BASE_URL}/${wiki_id}/${DUMP_DATE}/xml/bzip2/${wiki_id}-${DUMP_DATE}-${chunk}.xml.bz2 )"
 done
 


### PR DESCRIPTION
三个版本(0.1.10-r1 / 0.2.1-r1 / 0.5.1-r1)在 eclean、重新生成元数据时,depend 阶段触发 sandbox 违规、整个阶段中止(#11131)。

全局作用域的两个循环用 `read <<<` 拆分 `code:wiki:chunk` 来生成 IUSE/SRC_URI,here-string 会让 bash 创建临时文件。portage 3.0.81.2 起把 depend(元数据)阶段纳入 sandbox(bug #978846),此时工作目录可能不可写(例如 eclean 停在 /usr/lib/python3.14/site-packages),mkstemp 被拒绝,该包所有版本的元数据都无法生成。

改用参数展开(`${dump%%:*}` 等），不创建临时文件。按 PMS 8 §6,ebuild 载入时不得修改系统状态;在全局作用域用参数展开生成 IUSE/SRC_URI 也是官方写法(参见 app-text/tessdata_*）。生成的 IUSE（6 个 l10n）与 SRC_URI（34 条）与原先逐字节一致,revbump 为 -r1；phase 函数内的 `read <<<` 在可写的 WORKDIR 运行,未改动。

测试:在不可写工作目录下复现违规,修改后三个版本的 depend 均正常。

Closes #11131

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
