### PR TITLE
dev-util/vcpkg-tool: fix depend-phase sandbox violation

### DIFF
--- a/dev-util/vcpkg-tool/vcpkg-tool-2025.12.16-r1.ebuild
+++ b/dev-util/vcpkg-tool/vcpkg-tool-2025.12.16-r1.ebuild
@@ -7,9 +7,12 @@ inherit cmake
 
 DESCRIPTION="Library manager for C/C++ (tool only)"
 HOMEPAGE="https://github.com/microsoft/vcpkg-tool https://vcpkg.io/en/index.html"
+# Split with parameter expansion, not `read <<<`: a here-string needs a temp
+# file, which the sandboxed depend phase (metadata) cannot create (bug #978846).
 format-date() {
 	local input="$1"
-	IFS='.' read -r year month day <<< "$input"
+	local year="${input%%.*}" rest="${input#*.}"
+	local month="${rest%%.*}" day="${rest##*.}"
 	printf '%04d-%02d-%02d' "$year" "$month" "$day"
 }
 MY_PV="$(format-date "${PV}")"


### PR DESCRIPTION
重新生成元数据(depend 阶段)时触发 sandbox 违规,`aux_get exception` 失败。

`format-date()` 在全局作用域被调用(`MY_PV="$(format-date "${PV}")"`），内部用 `read <<<` 拆分日期 PV,here-string 会让 bash 创建临时文件。portage 3.0.81.2 起把 depend 阶段纳入 sandbox(bug #978846），此时工作目录可能不可写,mkstemp 被拒绝,元数据无法生成。

改用参数展开拆分日期,按 PMS 8 §6(ebuild 载入时不得修改系统状态)。`MY_PV` 结果不变(`2025.12.16` → `2025-12-16`），revbump 为 -r1。

测试:复现违规,修改后 depend 正常。同类问题见 #11131。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
