### PR TITLE
media-video/wiliwili: fix depend-phase sandbox violation

### DIFF
--- a/media-video/wiliwili/wiliwili-1.6.0-r1.ebuild
+++ b/media-video/wiliwili/wiliwili-1.6.0-r1.ebuild
@@ -77,8 +77,13 @@ BDEPEND="
 CMAKE_QA_COMPAT_SKIP=1
 
 submodule_uris() {
+	# Split with an array, not `read <<<`: a here-string needs a temp file,
+	# which the sandboxed depend phase (metadata) cannot create (bug #978846).
+	local line url commit
+	local -a fields
 	for line in "${SUBMODULES[@]}"; do
-		read -r dep proj url commit <<< "${line}" || die
+		fields=( ${line} )
+		url=${fields[2]} commit=${fields[3]}
 		SRC_URI+=" ${url}/archive/${commit}.tar.gz -> ${url##*/}-${commit}.tar.gz"
 	done
 }

--- a/media-video/wiliwili/wiliwili-1.6.0-r1.ebuild
+++ b/media-video/wiliwili/wiliwili-1.6.0-r1.ebuild
@@ -93,8 +93,6 @@ submodule_uris
 pkg_pretend() {
 	if ! use hwaccel; then
 		ewarn "USE=hwaccel not set, using software rendering, but it will affect performance."
-	else
-		ewarn "USE=hwaccel set, if your system does not support OpenGL(ES), this is useless."
 	fi
 }
 


### PR DESCRIPTION
重新生成元数据(depend 阶段)时触发 sandbox 违规,`aux_get exception` 失败。revbump 为 1.6.0-r1,两个改动:

**1. sandbox 修复** — `submodule_uris()` 在全局作用域被调用生成 SRC_URI,内部用 `read <<<` 拆分 SUBMODULES 每行,here-string 会让 bash 创建临时文件。portage 3.0.81.2 起把 depend 阶段纳入 sandbox(bug #978846），此时工作目录可能不可写,mkstemp 被拒绝。改用数组拆分,按 PMS 8 §6(ebuild 载入时不得修改系统状态)。SRC_URI 结果不变；`src_prepare` 内的 `read <<<` 在可写的 WORKDIR 运行,未改动。

**2. pkg_pretend** — 两个 `USE=hwaccel` 分支都会 `ewarn`,每次 emerge 都触发。默认开启 hwaccel 时触发的那句(“不支持 OpenGL 时无效”)信息量低,也会触发 overlay 的 elog 检查。删除该句,保留“未开启 hwaccel、使用软件渲染较慢”一句。

测试:复现 sandbox 违规,修改后 depend 正常；pkg_pretend 在开启 hwaccel(CI 默认)时无输出,关闭时才提示。同类问题见 #11131。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
