### PR TITLE
autobump: use gentoozh-bot for the bot commit identity

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -158,7 +158,7 @@ jobs:
     - name: git identity
       run: |
         git config --global --add safe.directory "$(realpath .)"
-        git config user.name  "gentoo-zh-bot"
+        git config user.name  "gentoozh-bot"
         git config user.email "bot@gentoozh.org"
 
     - name: restore state


### PR DESCRIPTION
autobump 提交用的 git `user.name` 之前写成 `gentoo-zh-bot`,和真实账号 @gentoozh-bot 对不上。改成 `gentoozh-bot`,sign-off 与账号一致。

邮箱 `bot@gentoozh.org` 已在该账号验证,提交本来就关联到它;这次只是把名字串对齐。只改 `.github/workflows/autobump.yml` 一行,不涉及 ebuild。