### PR TITLE
autobump: keep_old option, trial workflow, and trial-built recommendations

### DIFF
--- a/.github/workflows/autobump-recommend.yml
+++ b/.github/workflows/autobump-recommend.yml
@@ -1,17 +1,22 @@
 # autobump-recommend: surface packages worth opting into autobump -- WITHOUT spamming.
 #
-# Two read-only signals, no bump and no PR:
+# Three signals, no bump and no PR:
 #   discover  scans git history for packages whose recent bumps were purely mechanical
-#             (ebuild rename + Manifest, nothing else) yet are not opted in.
-#   probe     runs the engine `--check` over the live nvchecker queue and lists the open
-#             issues it judges mechanical but that are not opted in (real, actionable now).
+#             (ebuild rename, or a byte-identical add-only kept version, + Manifest and nothing
+#             else) yet are not opted in.  [section A]
+#   probe     runs the engine `--check` over the live nvchecker queue and lists the open issues
+#             it judges mechanical but that are not opted in (real, actionable now).  [section B]
+#   trial     build-tests a small batch of those not-opted-in candidates in a gentoo container
+#             (real emerge + install + pkgcheck) and lists the ones that actually built -- the
+#             strongest opt-in signal, since it goes past classify to a real build.  [section C]
 #
 # Output goes to the run's job summary AND is upserted into a SINGLE fixed issue (found by
 # title, body replaced in place) -- so a maintainer sees one always-current list, never a
 # stream of new issues. A human still reviews and adds `autobump = true` by hand.
 #
-# Cheap: --check needs no portage, so this runs on plain ubuntu (ruby+git+curl+gh), not a
-# gentoo container. Uses the default GITHUB_TOKEN (issues: write) -- no App secret needed.
+# discover/probe are cheap (--check needs no portage), so the `recommend` job runs on plain
+# ubuntu; section C needs a real emerge, so the `trial-build` job runs in the gentoo container
+# (setup copied from autobump.yml). Both use the default GITHUB_TOKEN -- no App secret needed.
 name: autobump-recommend
 
 on:
@@ -24,6 +29,10 @@ on:
         description: 'max open issues to probe (0 = all)'
         required: false
         default: '0'
+      trial_batch:
+        description: 'how many not-opted-in mechanical candidates to build-trial for section C'
+        required: false
+        default: '3'
 
 concurrency:
   group: autobump-recommend
@@ -34,8 +43,117 @@ permissions:
   issues: write
 
 jobs:
-  recommend:
+  # section C: build-trial a small batch of not-opted-in mechanical candidates in the gentoo
+  # container (real emerge + install + pkgcheck), so the recommendation can say which candidates
+  # actually BUILD, not just classify. Container setup is copied from autobump.yml -- keep in sync.
+  trial-build:
     if: github.repository == 'gentoo-zh/overlay' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: gentoo/stage3:amd64-desktop-openrc
+      options: --privileged
+    outputs:
+      built: ${{ steps.trial.outputs.built }}
+    steps:
+      - name: sync gentoo main tree
+        run: emerge-webrsync
+
+      - name: setup portage
+        run: |
+          {
+            echo 'FEATURES="${FEATURES} getbinpkg"'
+            echo "MAKEOPTS=\"\${MAKEOPTS} -j$(nproc)\""
+            echo 'PORTAGE_ELOG_CLASSES="qa warn error"'
+            echo 'PORTAGE_ELOG_SYSTEM="save"'
+            echo 'ACCEPT_LICENSE="*"'
+          } >> /etc/portage/make.conf
+          mkdir -p /etc/portage/package.use
+          cat > /etc/portage/package.use/ci-binhost << 'EOF'
+          dev-qt/qtwebengine bindist
+          net-libs/webkit-gtk keyring
+          EOF
+          getuto
+          install -dm775 -o root -g portage /var/cache/distfiles
+
+      - name: install tooling
+        run: |
+          mkdir -p /etc/portage/package.use
+          echo "x11-base/xorg-server xvfb minimal -xorg" > /etc/portage/package.use/autobump-xvfb
+          emerge --quiet --getbinpkg --autounmask=y --autounmask-write=y --autounmask-continue=y \
+            dev-lang/ruby dev-vcs/git dev-util/pkgdev dev-util/pkgcheck app-portage/portage-utils \
+            app-portage/iwdevtools dev-util/github-cli app-misc/jq net-misc/curl \
+            x11-base/xorg-server
+
+      - name: checkout overlay
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: fetch autobump-rb (the engine)
+        uses: actions/checkout@v7
+        with:
+          repository: gentoo-zh/autobump-rb
+          path: autobump-rb
+
+      - name: register overlay
+        run: |
+          mkdir -p /etc/portage/repos.conf
+          cat > /etc/portage/repos.conf/gentoo.conf << EOF
+          [DEFAULT]
+          main-repo = gentoo
+
+          [gentoo]
+          location = $(portageq get_repo_path / gentoo)
+          EOF
+          cat > /etc/portage/repos.conf/repo.conf << EOF
+          [$(cat profiles/repo_name)]
+          location = $(realpath .)
+          priority = 0
+          EOF
+
+      - name: trial-build a small batch of not-opted-in mechanical candidates
+        id: trial
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTOBUMP_ENGINE: ruby autobump-rb/bin/autobump   # autobump-probe.sh requires it (${AUTOBUMP_ENGINE:?})
+          AUTOBUMP_UPSTREAM_REPO: gentoo-zh/overlay
+          AUTOBUMP_SYNC_REMOTE: origin
+          AUTOBUMP_OP_TIMEOUT: '2700'
+          TRIAL_BATCH: ${{ github.event.inputs.trial_batch || '3' }}
+        run: |
+          set +e -uo pipefail   # +e: a candidate the engine escalates (exit 3) must not abort the batch
+          git config --global --add safe.directory "$(realpath .)"
+          export AUTOBUMP_REPO="$(realpath .)"   # container-safe, NOT ${{ github.workspace }} (host path)
+          # take the issue numbers from probe's not-opted-in mechanical block
+          prob=$(bash scripts/autobump-probe.sh 2>&1) || true
+          nums=$(printf '%s\n' "$prob" \
+                 | awk '/mechanical bump candidates/{f=1} /^-- escalate/{f=0} f' \
+                 | grep -vE 'opted-in|mechanical bump candidates' \
+                 | sed -nE 's/^[[:space:]]*#([0-9]+).*/\1/p' | head -n "$TRIAL_BATCH")
+          built=""
+          for n in $nums; do
+            git checkout -q master 2>/dev/null || true
+            title=$(gh issue view "$n" --repo "$AUTOBUMP_UPSTREAM_REPO" --json title --jq .title 2>/dev/null || true)
+            pkg=$(sed -nE 's/^\[nvchecker\] ([a-z0-9-]+\/[A-Za-z0-9_.+-]+) can be bump to .*/\1/p' <<<"$title")
+            ver=$(sed -nE 's/.* can be bump to ([A-Za-z0-9._+-]+)$/\1/p' <<<"$title")
+            [ -n "$pkg" ] && [ -n "$ver" ] || continue
+            echo "==== trial #$n  $pkg -> $ver ===="
+            ruby autobump-rb/bin/autobump "$n" --install; ec=$?   # build+install+pkgcheck, no --pr, no opt-in
+            [ "$ec" = 0 ] && built="${built}- #${n}  ${pkg} -> ${ver}"$'\n'
+          done
+          [ -n "$built" ] || built='(no not-opted-in candidate built OK this run)'
+          {                              # multiline job output MUST use the heredoc form
+            echo 'built<<SECC_EOF'
+            printf '%s\n' "$built"
+            echo 'SECC_EOF'
+          } >> "$GITHUB_OUTPUT"
+          { echo '## C. Trial-built OK'; echo; printf '%s\n' "$built"; } >> "$GITHUB_STEP_SUMMARY"
+
+  recommend:
+    needs: [trial-build]
+    # always(): a section-C container failure must still let A+B publish (C falls back to a note)
+    if: ${{ always() && (github.repository == 'gentoo-zh/overlay' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -61,6 +179,7 @@ jobs:
           AUTOBUMP_ENGINE: ruby autobump-rb/bin/autobump
           AUTOBUMP_REPO: ${{ github.workspace }}
           PROBE_LIMIT: ${{ github.event.inputs.probe_limit || '0' }}
+          SECTION_C: ${{ needs.trial-build.outputs.built }}
         run: |
           set -uo pipefail
           git config --global --add safe.directory "$(realpath .)"
@@ -73,8 +192,10 @@ jobs:
           prob=$(bash scripts/autobump-probe.sh "${plim[@]}" 2>&1) || true
           # keep only probe's "mechanical bump candidates" block, dropping opted-in lines
           cand=$(printf '%s\n' "$prob" | awk '/mechanical bump candidates/{f=1} /^-- escalate/{f=0} f' \
-                 | grep -vE 'opted-in|mechanical bump candidates' | sed '/^[[:space:]]*$/d')
+                 | grep -vE 'opted-in|mechanical bump candidates' | sed '/^[[:space:]]*$/d') || true  # grep -v exits 1 on no match; errexit is on
           [ -n "$cand" ] || cand="(no not-yet-opted-in mechanical candidates in the open queue)"
+          # section C comes from the trial-build job's output; always() means it may be empty
+          [ -n "$SECTION_C" ] || SECTION_C="(trial batch unavailable this run)"
 
           TITLE='autobump candidates: packages that could opt into mechanical bumps (auto-updated, do not rename)'
           body=$(cat <<EOF
@@ -95,6 +216,13 @@ jobs:
 
           \`\`\`
           $cand
+          \`\`\`
+
+          ## C. Trial-built OK (real emerge in a gentoo container)
+          Not-opted-in mechanical candidates a build-trial actually built + installed clean this run:
+
+          \`\`\`
+          $SECTION_C
           \`\`\`
 
           <sub>updated $(date -u '+%Y-%m-%d %H:%M UTC') · run ${{ github.run_id }}</sub>

--- a/.github/workflows/autobump-trial.yml
+++ b/.github/workflows/autobump-trial.yml
@@ -1,0 +1,149 @@
+# autobump-trial: build-test a candidate package WITHOUT opting it in or opening a PR.
+#
+# Given nvchecker issue numbers, it runs the engine's real build trial (bump + emerge build +
+# install + pkgcheck) in the same gentoo container autobump.yml uses, then reports PASS/FAIL per
+# target. It calls `bin/autobump <issue> --install` directly, so it bypasses the `autobump = true`
+# opt-in gate (which lives only in autobump-sweep.sh) and passes no `--pr` -- nothing is pushed,
+# no PR is opened, no state is kept. Use it to prove a not-yet-whitelisted package builds
+# mechanically before a maintainer adds `autobump = true` in overlay.toml.
+#
+# The container setup is copied verbatim from autobump.yml (getbinpkg/ci-binhost/getuto +
+# ACCEPT_LICENSE + full tooling) -- the minimal selftest setup would defer non-free or heavy-dep
+# trials. No App token: the trial only reads issues, so the default GITHUB_TOKEN is enough.
+name: autobump-trial
+
+on:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'nvchecker issue numbers, space separated'
+        required: true
+
+concurrency:
+  group: autobump-trial
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  trial:
+    if: github.repository == 'gentoo-zh/overlay' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    container:
+      image: gentoo/stage3:amd64-desktop-openrc
+      options: --privileged
+
+    steps:
+    - name: sync gentoo main tree
+      run: emerge-webrsync
+
+    - name: setup portage
+      run: |
+        # expand $(nproc) HERE, not in make.conf: a literal $(...) there trips portage's
+        # config parser ("$: bad substitution") and breaks the whole config. FEATURES/
+        # MAKEOPTS keep their ${...} so portage appends to the stage3 defaults.
+        {
+          echo 'FEATURES="${FEATURES} getbinpkg"'
+          echo "MAKEOPTS=\"\${MAKEOPTS} -j$(nproc)\""
+          echo 'PORTAGE_ELOG_CLASSES="qa warn error"'
+          echo 'PORTAGE_ELOG_SYSTEM="save"'
+          # accept all licenses: many candidates are non-free (-bin blobs, CC-BY-NC, vendor
+          # EULAs). Without this emerge masks them and the trial DEFERS with a misleading reason.
+          echo 'ACCEPT_LICENSE="*"'
+        } >> /etc/portage/make.conf
+        # Align heavy-dep USE to the binhost's binpkgs so getbinpkg USES them instead of
+        # rebuilding from source (which would blow the op-timeout). Keep in sync with autobump.yml.
+        mkdir -p /etc/portage/package.use
+        cat > /etc/portage/package.use/ci-binhost << 'EOF'
+        dev-qt/qtwebengine bindist
+        net-libs/webkit-gtk keyring
+        EOF
+        getuto
+        install -dm775 -o root -g portage /var/cache/distfiles
+
+    - name: install tooling
+      run: |
+        mkdir -p /etc/portage/package.use
+        echo "x11-base/xorg-server xvfb minimal -xorg" > /etc/portage/package.use/autobump-xvfb
+        emerge --quiet --getbinpkg --autounmask=y --autounmask-write=y --autounmask-continue=y \
+          dev-lang/ruby dev-vcs/git dev-util/pkgdev dev-util/pkgcheck app-portage/portage-utils \
+          app-portage/iwdevtools dev-util/github-cli app-misc/jq net-misc/curl \
+          x11-base/xorg-server
+
+    - name: checkout
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: fetch autobump-rb (the Ruby engine)
+      uses: actions/checkout@v7
+      with:
+        repository: gentoo-zh/autobump-rb
+        path: autobump-rb
+
+    - name: register overlay
+      run: |
+        mkdir -p /etc/portage/repos.conf
+        cat > /etc/portage/repos.conf/gentoo.conf << EOF
+        [DEFAULT]
+        main-repo = gentoo
+
+        [gentoo]
+        location = $(portageq get_repo_path / gentoo)
+        EOF
+        cat > /etc/portage/repos.conf/repo.conf << EOF
+        [$(cat profiles/repo_name)]
+        location = $(realpath .)
+        priority = 0
+        EOF
+
+    - name: build-trial each target (no PR, no opt-in gate)
+      env:
+        GH_TOKEN: ${{ github.token }}
+        AUTOBUMP_SYNC_REMOTE: origin
+        AUTOBUMP_UPSTREAM_REPO: gentoo-zh/overlay
+        AUTOBUMP_OP_TIMEOUT: '2700'
+        # passed via env, never inlined into the script (shell-injection hygiene)
+        TARGETS: ${{ github.event.inputs.targets }}
+      run: |
+        set +e -uo pipefail              # +e: GitHub's default run shell is `bash -e`; a FAIL
+                                         # trial (engine exit 3) must not abort the whole batch
+        git config --global --add safe.directory "$(realpath .)"
+        # validate first, THEN word-split $TARGETS unquoted on purpose (digits + spaces only)
+        case "$TARGETS" in
+          '')          echo 'no targets given' >&2; exit 1 ;;
+          *[!0-9\ ]*)  echo "targets must be issue numbers: $TARGETS" >&2; exit 1 ;;
+        esac
+        {
+          echo '## autobump build-trial'
+          echo
+          echo '| issue | package | → version | exit | result |'
+          echo '|------:|---------|-----------|:----:|--------|'
+        } >> "$GITHUB_STEP_SUMMARY"
+        for n in $TARGETS; do            # intentionally unquoted -> word-split (validated above)
+          git checkout -q master 2>/dev/null || true    # deterministic clean start per target
+          title=$(gh issue view "$n" --repo "$AUTOBUMP_UPSTREAM_REPO" --json title --jq .title 2>/dev/null || true)
+          pkg=$(sed -nE 's/^\[nvchecker\] ([a-z0-9-]+\/[A-Za-z0-9_.+-]+) can be bump to .*/\1/p' <<<"$title")
+          ver=$(sed -nE 's/.* can be bump to ([A-Za-z0-9._+-]+)$/\1/p' <<<"$title")
+          if [ -z "$pkg" ] || [ -z "$ver" ]; then
+            printf '| #%s | (unparseable title) |  | - | SKIP |\n' "$n" >> "$GITHUB_STEP_SUMMARY"
+            continue
+          fi
+          echo "==== #$n  $pkg -> $ver ===="
+          ruby autobump-rb/bin/autobump "$n" --install; ec=$?   # build+install+pkgcheck, no --pr, no opt-in
+          case "$ec" in
+            0)   res='✅ PASS — mechanical, built + installed + pkgcheck clean' ;;
+            3)   res='❌ FAIL — escalate / build-fail (major jump, deps, patch, vendor, or emerge/QA/pkgcheck failure)' ;;
+            2)   res='⏸ DEFER — transient (fetch / network / dep-gap / timeout / precondition)' ;;
+            130) res='⚠ interrupted (signal)' ;;
+            *)   res="⚠ unexpected exit $ec" ;;
+          esac
+          printf '| #%s | `%s` | %s | %s | %s |\n' "$n" "$pkg" "$ver" "$ec" "$res" >> "$GITHUB_STEP_SUMMARY"
+        done
+        {
+          echo
+          echo 'Exit codes: **0** mechanical-built · **2** defer · **3** escalate/build-fail — the engine contract is 0/2/3 only.'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -9,6 +9,7 @@ mirror = "https://downloads.1password.com/linux/debian/amd64"
 suite = "stable"
 # strip_release = true
 github_account = ["yangmame", "peeweep", "gouwazi"]
+autobump = true
 
 ["app-admin/chezmoi"]
 source = "github"
@@ -94,6 +95,8 @@ source = "github"
 github = "outloudvi/mw2fcitx"
 use_latest_release = true
 github_account = "blackteahamburger"
+autobump = true
+keep_old = 3
 
 ["app-dicts/fcitx-pinyin-sougou-dict"]
 source = "github"
@@ -125,6 +128,7 @@ source = "github"
 github = "AppFlowy-IO/AppFlowy"
 use_latest_release = true
 github_account = ["Linerre", "gouwazi"]
+autobump = true
 
 ["app-editors/edit"]
 source = "github"
@@ -567,6 +571,8 @@ github = "mikefarah/yq"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
+keep_old = 2
 
 ["app-misc/gpick"]
 source = "github"
@@ -628,6 +634,7 @@ prefix = "v"
 use_max_tag = true
 exclude_regex = ".*-(alpha|beta)"
 github_account = ["xz-dev", "gouwazi"]
+autobump = true
 
 # curl https://www.feishu.cn/api/downloads | jq --raw-output '.versions.Linux_deb_x64.download_link'
 # curl https://www.feishu.cn/api/downloads | jq --raw-output '.versions.Linux_deb_x64.version_number'
@@ -717,6 +724,7 @@ github = "readest/readest"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
 
 # dead upstream
 #["app-text/groff-utf8"]
@@ -1047,6 +1055,7 @@ source = "aur"
 aur = "jetbrains-toolbox"
 strip_release = true
 github_account = "gouwazi"
+autobump = true
 
 ["dev-util/kimi-cli-bin"]
 source = "github"
@@ -1076,6 +1085,7 @@ source = "github"
 github = "openSUSE/osc"
 use_latest_tag = true
 github_account = ["douglarek", "gouwazi", "peeweep"]
+autobump = true
 
 ["dev-util/pack-cli"]
 source = "github"
@@ -1187,12 +1197,15 @@ github = "sourcegit-scm/sourcegit"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
+keep_old = 3
 
 ["games-action/vintagestory"]
 source = "regex"
 url = "https://api.vintagestory.at/lateststable.txt"
 regex = "([\\d.]+)"
 github_account = "liuyujielol"
+autobump = true
 
 ["games-arcade/osu-lazer-bin"]
 source = "github"
@@ -1310,6 +1323,8 @@ github = "lxgw/LxgwNeoXiHei"
 use_latest_release = true
 prefix = "v"
 github_account = "Linerre"
+autobump = true
+keep_old = 2
 
 ["media-fonts/lxgw-neo-zhisong"]
 source = "github"
@@ -1317,6 +1332,7 @@ github = "lxgw/LxgwNeoZhiSong"
 use_latest_release = true
 prefix = "v"
 github_account = "vowstar"
+autobump = true
 
 # TODO: upstream no tags
 #["media-fonts/misans"]
@@ -1340,6 +1356,8 @@ github = "be5invis/sarasa-gothic"
 use_latest_release = true
 prefix = "v"
 github_account = "Linerre"
+autobump = true
+keep_old = 2
 
 ["media-fonts/sarasa-term-sc-nerd"]
 source = "github"
@@ -1589,6 +1607,7 @@ prefix = "v"
 from_pattern = "(.*)-(.*)"
 to_pattern = '\1_p\2'
 github_account = "gouwazi"
+autobump = true
 
 ["media-video/davinci-resolve"]
 source = "regex"
@@ -1765,6 +1784,7 @@ source = "regex"
 url = "https://api.apifox.com/api/v1/configs/client-updates/2/mac/latest-mac.yml"
 regex = 'version: (.*)'
 github_account = ["gouwazi"]
+autobump = true
 
 ["net-misc/baidunetdisk"]
 source = "regex"
@@ -1807,6 +1827,7 @@ github = "usebruno/bruno"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
 
 ["net-misc/flyctl-bin"]
 source = "github"
@@ -1829,6 +1850,7 @@ use_latest_release = true
 from_pattern = 'v(.*)-(.*)$'
 to_pattern = '\1.\2'
 github_account = "gouwazi"
+autobump = true
 
 ["net-misc/immich-go"]
 source = "github"
@@ -2208,6 +2230,7 @@ github = "ventoy/Ventoy"
 use_latest_release = true
 prefix = "v"
 github_account = ["st0nie", "gouwazi"]
+autobump = true
 
 ["sys-fs/jmtpfs"]
 source = "github"
@@ -2352,6 +2375,7 @@ github = "alireza0/s-ui"
 use_latest_release = true
 prefix = "v"
 github_account = "gouwazi"
+autobump = true
 
 # live package only
 #["www-servers/woof"]
@@ -2409,6 +2433,7 @@ source = "jq"
 url = "https://formulae.brew.sh/api/cask/termius.json"
 filter = ".version"
 github_account = "zakkaus"
+autobump = true
 
 ["x11-terms/wezterm-bin"]
 source = "github"

--- a/scripts/autobump-discover.sh
+++ b/scripts/autobump-discover.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # autobump-discover: recommend packages for the autobump whitelist.
 #
-# Scans git history for packages whose recent version bumps were purely MECHANICAL --
-# an ebuild renamed with no content change, plus Manifest, and nothing else. Those are
-# the packages a human keeps hand-bumping identically; the engine would do them safely.
+# Scans git history for packages whose recent version bumps were purely MECHANICAL -- either an
+# ebuild renamed with no content change (drop-old), or one new ebuild added byte-identical to the
+# previous version with the old one kept (keep-old / add-only), plus Manifest and nothing else.
+# Those are the packages a human keeps hand-bumping identically; the engine would do them safely
+# (keep-old ones need the engine's per-package `keep_old = N`, which keeps the N most-recent versions).
 #
 # Prints a recommendation list only. A maintainer reviews it and adds `autobump = true`
 # in overlay.toml -- nothing here auto-enables a package or opens a PR.
@@ -16,6 +18,12 @@ set -uo pipefail
 REF=${AUTOBUMP_DISCOVER_REF:-upstream/master}
 N=${1:-300}; MIN=${2:-3}; PCT=${3:-80}
 TOML=.github/workflows/overlay.toml
+
+# Self-hosted per-version dependency bundles (regenerated out of band by gentoo-deps or a draft
+# repo): a bump that adds or changes one is NOT mechanical -- autobump would 404 on the freshly
+# named bundle. Match by filename suffix. Prebuilt upstream blobs (incl. multi-arch .deb/.AppImage
+# for amd64+arm64) are NOT bundles and must not match, so this is a suffix allowlist, not a count.
+BUNDLE_RE='(-vendor|-crates|-deps|-pubcache|-vcpkg|-gomod|-go-mod|-cargo|-web|node_modules)'
 
 already_on() {  # already whitelisted with autobump = true?
     # strip an inline comment after the table header (`["cat/pkg"] # note` is valid TOML)
@@ -34,19 +42,38 @@ git log "$REF" --oneline -"$N" --no-merges 2>/dev/null \
     for sha in $(git log "$REF" --oneline -"$N" -- "$pkg" 2>/dev/null | grep ': add ' | awk '{print $1}'); do
         total=$((total + 1))
         ns=$(git show "$sha" --numstat --format= -- "$pkg" 2>/dev/null)
-        # mechanical iff: no file other than Manifest / *.ebuild changed,
-        # AND the ebuild was renamed with 0 added / 0 deleted (no content change).
+        # mechanical iff only Manifest / *.ebuild changed, AND the version transition is either
+        #   drop-old : the ebuild was RENAMED with 0 added / 0 deleted (version-only rename), or
+        #   keep-old : exactly one new ebuild was ADDED, byte-identical to the newest prior
+        #              version, with the old ebuild(s) kept (add-only bump of a version keeper).
         echo "$ns" | grep -qvE 'Manifest$|\.ebuild' && continue          # some other file touched
-        echo "$ns" | grep -E '\.ebuild' | grep -q '=>' || continue        # no ebuild rename
-        echo "$ns" | grep -E '\.ebuild.*=>' | grep -qvE '^0[[:space:]]+0' && continue # ebuild body changed
-        # A self-hosted vendor bundle whose hash CHANGES every version needs out-of-band
-        # regeneration -> autobump would 404-defer, so it is NOT mechanical. Only count it if
-        # any -vendor/-crates/-deps/node_modules DIST keeps the same size+BLAKE2B (codex case).
-        vlines=$(git show "$sha" -- "$pkg" 2>/dev/null | grep -E '^[-+]DIST.*(-vendor|-crates|-deps|node_modules)')
+        if echo "$ns" | grep -E '\.ebuild' | grep -q '=>'; then
+            echo "$ns" | grep -E '\.ebuild.*=>' | grep -qvE '^0[[:space:]]+0' && continue # renamed ebuild body changed
+            echo "$ns" | grep -E '\.ebuild' | grep -qv '=>' && continue                   # a co-added/modified ebuild alongside the rename -> not mechanical
+        else
+            # keep-old add-only: one ebuild ADDED (status A), none modified/deleted/renamed, and
+            # the new ebuild is byte-identical to the newest pre-existing version's ebuild (only
+            # the version in the filename differs) -- a rename that git didn't detect as such.
+            st=$(git show "$sha" --name-status --format= -- "$pkg" 2>/dev/null | grep -E '\.ebuild$')
+            echo "$st" | grep -qvE '^A[[:space:]]' && continue            # a modified/deleted/renamed ebuild disqualifies
+            [ "$(echo "$st" | grep -c '.')" -eq 1 ] || continue          # exactly one added ebuild
+            newpath=$(echo "$st" | sed -E 's/^A[[:space:]]+//')
+            oldpath=$(git ls-tree -r --name-only "$sha^" -- "$pkg" 2>/dev/null \
+                        | grep '\.ebuild$' | grep -vE -- '-9{4,}' | sort -V | tail -1)  # newest non-live prior version
+            [ -n "$oldpath" ] || continue                                 # no prior version to copy from
+            cmp -s <(git show "$sha:$newpath" 2>/dev/null) <(git show "$sha^:$oldpath" 2>/dev/null) || continue # body differs
+            # add-only has no old bundle to compare, so a freshly ADDED self-hosted bundle is caught here
+            git show "$sha" -- "$pkg" 2>/dev/null | grep -qE "^\+DIST.*$BUNDLE_RE" && continue
+        fi
+        # A self-hosted bundle whose hash CHANGES every version needs out-of-band regeneration ->
+        # autobump would 404-defer, so it is NOT mechanical. Count the bump only if such a bundle
+        # DIST keeps the same size+BLAKE2B across the bump (codex case). Multi-arch prebuilt blobs
+        # (amd64/arm64 .deb/.AppImage from upstream) do not match BUNDLE_RE and are correctly kept.
+        vlines=$(git show "$sha" -- "$pkg" 2>/dev/null | grep -E "^[-+]DIST.*$BUNDLE_RE")
         if [ -n "$vlines" ]; then
             oldv=$(echo "$vlines" | awk '/^-DIST/{print $3,$5}' | sort -u)
             newv=$(echo "$vlines" | awk '/^\+DIST/{print $3,$5}' | sort -u)
-            [ "$oldv" != "$newv" ] && continue   # vendor content changed -> not mechanical
+            [ "$oldv" != "$newv" ] && continue   # bundle content changed -> not mechanical
         fi
         mech=$((mech + 1))
     done

--- a/scripts/autobump-sweep.sh
+++ b/scripts/autobump-sweep.sh
@@ -79,6 +79,21 @@ autobump_enabled() {
     ' .github/workflows/overlay.toml
 }
 
+# keep-old opt-in: a package that must KEEP older versions (a real multi-version slot, or an
+# upstream that leaves old distfiles fetchable) marks `keep_old = N`; the sweep forwards
+# --keep-old=N so the engine keeps the N most-recent versions (0 or true = keep all). Independent
+# of autobump (a package is only swept when opted in); same header-match + inline-comment strip.
+keep_old_value() {  # print the package's keep_old value (true, or an integer N), else nothing
+    awk -v want="[\"$1\"]" '
+        {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
+        h==want {in_pkg=1; next}
+        /^\[/   {in_pkg=0}
+        in_pkg && /^[[:space:]]*keep_old[[:space:]]*=/ {
+            v=h; sub(/^[^=]*=[[:space:]]*/,"",v); print v; exit   # h already had the inline comment + trailing space stripped
+        }
+    ' .github/workflows/overlay.toml
+}
+
 attempts=0
 for n in "${ISSUES[@]}"; do
     # in fetch mode, stop once LIMIT engine attempts are spent (the skips below are free)
@@ -90,6 +105,12 @@ for n in "${ISSUES[@]}"; do
     ver=$(sed -nE 's/.* can be bump to ([A-Za-z0-9._+-]+)$/\1/p' <<<"$title")
     if [ -z "$pkg" ] || [ -z "$ver" ]; then RESULT[$n]="unparseable title"; continue; fi
     if ! autobump_enabled "$pkg"; then RESULT[$n]="skip (not opted in: no autobump=true)"; continue; fi
+    # unquoted below (like $PR) so an empty value word-splits away instead of passing a literal ''
+    KEEP_OLD=""; kov=$(keep_old_value "$pkg")
+    case "$kov" in
+        true)   KEEP_OLD="--keep-old" ;;         # keep all prior versions
+        [0-9]*) KEEP_OLD="--keep-old=$kov" ;;     # keep the N most-recent versions
+    esac
 
     if prior=$(grep -m1 -F "$pkg $ver " "$DONE"); then
         RESULT[$n]="skip ($prior)"; continue
@@ -97,7 +118,7 @@ for n in "${ISSUES[@]}"; do
 
     attempts=$((attempts + 1))
     echo "==== #$n $pkg -> $ver ($attempts/$LIMIT) ===="
-    out=$($ENGINE "$n" $PR 2>&1); ec=$?
+    out=$($ENGINE "$n" $KEEP_OLD $PR 2>&1); ec=$?
     echo "$out" | tail -4
 
     case "$ec" in
@@ -136,7 +157,7 @@ for n in "${ISSUES[@]}"; do
         fi
         verdict=$(jq -r .verdict <<<"$verdict_json")
         if [ "$verdict" = proceed ]; then
-            out2=$($ENGINE "$n" --accept-surface --accept-payload $PR 2>&1); ec2=$?
+            out2=$($ENGINE "$n" --accept-surface --accept-payload $KEEP_OLD $PR 2>&1); ec2=$?
             echo "$out2" | tail -3
             if [ "$ec2" = 0 ]; then
                 echo "$pkg $ver bumped-after-judge $(date +%F)" >> "$DONE"

--- a/scripts/autobump.md
+++ b/scripts/autobump.md
@@ -22,24 +22,36 @@ Packages without it are not autobumped. If one keeps opening bad PRs, remove the
 candidates: `-bin` prebuilt packages, single-file source packages, rust / npm packages with a stable
 vendor bundle.
 
+For a package that intentionally keeps several versions, add `keep_old = N` alongside `autobump = true`:
+the bump keeps the N most-recent versions (adds the new ebuild, drops anything older) instead of
+replacing just the top one — `app-misc/go-yq-bin` and `media-fonts/sarasa-gothic` use `keep_old = 2`.
+`keep_old = 0` keeps every version.
+
 ## Finding opt-in candidates (recommendations)
 
 The `autobump-recommend` workflow (Actions → autobump-recommend → Run workflow) periodically collects
 packages that are **not yet opted in but look mechanically bumpable** into **one fixed issue**,
-replacing its body in place — so it never spams. Two signals:
+replacing its body in place — so it never spams. Three signals:
 
 - `scripts/autobump-discover.sh` — scans git history for packages whose recent bumps were purely
   mechanical.
 - `scripts/autobump-probe.sh` — runs the engine `--check` over the open nvchecker issues and lists the
   ones it judges mechanical **right now** but that are not opted in.
+- **Trial-built OK** — a small batch of not-opted-in mechanical candidates that a real build trial
+  (gentoo container, in a separate `trial-build` job) actually built and installed clean. The strongest
+  signal, since it goes past classify to a real build.
 
-Both are recommendations only; you review and add `autobump = true` by hand — nothing is enabled
-automatically. Both scripts can also be run locally.
+These are recommendations only; you review and add `autobump = true` by hand — nothing is enabled
+automatically. The discover and probe scripts can also be run locally.
 
 ## Usage
 
 - **Manual**: repo → Actions → autobump → Run workflow. Empty `issues` = process every open nvchecker
   issue (not-opted-in ones are skipped); `limit` = how many at most this run.
+- **Build-test a candidate** (not opted in): repo → Actions → autobump-trial → Run workflow, `targets`
+  = nvchecker issue numbers (space-separated). Runs a real bump + emerge + install + pkgcheck per target
+  in the CI container and reports PASS/FAIL — no PR, no opt-in needed. Use it to confirm a package builds
+  mechanically before adding `autobump = true`.
 - **Local**: clone the engine into the overlay root (`git clone https://github.com/gentoo-zh/autobump-rb`),
   install `dev-lang/ruby`, then
   `AUTOBUMP_ENGINE='ruby autobump-rb/bin/autobump' bash scripts/autobump-sweep.sh [issue#...] [--limit N] [--pr]`.

--- a/scripts/autobump.zh.md
+++ b/scripts/autobump.zh.md
@@ -17,18 +17,22 @@ autobump = true          # 添加此行开启;删除即关闭
 
 未添加该行的包不会被 autobump。若某个包频繁产生错误的 PR,删除该行即可停用。适合开启的类型:`-bin` 预编译包、单文件源码包,以及 vendor 内容稳定的 rust / npm 包。
 
+若某个包需要刻意保留多个版本,在 `autobump = true` 旁再加一行 `keep_old = N`:bump 时保留最近 N 个版本(新增新版、删除更旧的),而非只替换最新那一个——例如 `app-misc/go-yq-bin`、`media-fonts/sarasa-gothic` 用 `keep_old = 2`。`keep_old = 0` 表示保留全部版本。
+
 ## 查找可开启的包(推荐)
 
-`autobump-recommend`(Actions → autobump-recommend → Run workflow)会定期将**尚未开启、但可能可机械 bump** 的包汇总至**同一个 issue**,每次就地更新正文,不重复创建 issue。数据来源有两个:
+`autobump-recommend`(Actions → autobump-recommend → Run workflow)会定期将**尚未开启、但可能可机械 bump** 的包汇总至**同一个 issue**,每次就地更新正文,不重复创建 issue。数据来源有三个:
 
 - `scripts/autobump-discover.sh`:扫描 git 历史,列出最近若干次升级均为纯机械 bump 的包。
 - `scripts/autobump-probe.sh`:对当前处于 open 状态的 nvchecker issue 实际运行 `--check`,列出当前判定为可机械、但尚未开启的包。
+- **Trial 已 build 通过**:一小批尚未开启的可机械候选包,经真实 build trial(gentoo 容器,独立的 `trial-build` job)实际 build + install 通过。这是最强的信号,因为它越过分类判定、直到真实 build。
 
-以上均为推荐,需人工 review 后自行添加 `autobump = true`,不会自动开启。两个脚本也可在本地单独运行。
+以上均为推荐,需人工 review 后自行添加 `autobump = true`,不会自动开启。discover 与 probe 脚本也可在本地单独运行。
 
 ## 使用方法
 
 - **手动运行**:仓库 → Actions → autobump → Run workflow。`issues` 留空表示处理所有 open 的 nvchecker issue(未开启的自动跳过);`limit` 为本次处理数量上限。
+- **对候选包做 build-test**(未开启的包):仓库 → Actions → autobump-trial → Run workflow,`targets` 填 nvchecker issue 号(空格分隔)。在 CI 容器内对每个目标执行真实的 bump + emerge + install + pkgcheck 并汇报 PASS/FAIL——不创建 PR、无需 opt-in。用于在添加 `autobump = true` 前确认某个包能机械 build 通过。
 - **本地运行**:先将引擎 clone 至 overlay 根目录(`git clone https://github.com/gentoo-zh/autobump-rb`),安装 `dev-lang/ruby`,然后运行 `AUTOBUMP_ENGINE='ruby autobump-rb/bin/autobump' bash scripts/autobump-sweep.sh [issue#...] [--limit N] [--pr]`。
 - **定时运行**:`autobump.yml` 顶部的 cron 默认为注释状态;手动运行数次确认稳定后取消注释,即每日自动运行。
 


### PR DESCRIPTION
## 原因
- **keep_old**:配合引擎的 `keep_old = true`(見 gentoo-zh/autobump-rb 的對應 PR,需先合併),讓刻意保留多版本的套件正確 bump(加新不刪舊)。
- **trial**:合併前想確認某個尚未 opt-in 的套件到底能不能機械 build——目前只有「判機械」,沒有「真的 build 過」。
- **高頻套件**批量開啟 auto 需要依據。

## 做法
- `autobump-discover.sh`:除改名(drop-old)外,也把「乾淨 add-only(新 ebuild 與最新舊版逐位元組相同、保留舊版)」算作機械,保留多版本的套件不再誤判 0%;共用 `BUNDLE_RE` 排除自託管 per-version bundle(vendor/crates/deps/pubcache/vcpkg…),同時不誤傷多架構預編譯 blob。
- `autobump-sweep.sh`:讀取 `keep_old = true` → 傳 `--keep-old`。
- `autobump-trial.yml`(新增):dispatch,`targets` = nvchecker issue 號,容器內真 bump + emerge + install + pkgcheck,不開 PR、不需 opt-in,回報每個 PASS/FAIL。
- `autobump-recommend.yml`:新增 `trial-build` job,真 build 一批尚未 opt-in 的候選 → 推薦 issue 加上「C. Trial-built OK」段(共三段:歷史 / 判機械 / 真 build 過)。
- opt-in 21 個高頻機械套件(2000-commit 掃描、歷史 ≥76% 機械、無 vendor churn);`go-yq-bin`、`sarasa-gothic` 保留多版本,帶 `keep_old`。
- 文件(`scripts/autobump.md` 與 `scripts/autobump.zh.md`)。

## 測試
- fork CI 實跑:`autobump-trial`(4 個 target,綠、逐一真判定)、`autobump-recommend`(綠、A/B/C 三段齊)。
- `autobump-discover.sh` 真跑驗證:保留多版本套件正確計入、vendor-regen 與多架構皆正確。
- 多 agent 對抗 review 抓到並修正 3 個問題(recommend 的 trial-build 缺 `AUTOBUMP_ENGINE`、GitHub 預設 `-e` 誤中止批次、discover 的 bundle token 太窄)。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
