### PR TITLE
net-print, media-gfx, games: fix builds with modern GCC

### DIFF
--- a/games-roguelike/tsl/tsl-0.40-r3.ebuild
+++ b/games-roguelike/tsl/tsl-0.40-r3.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2025 Gentoo Authors
+# Copyright 2025-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -45,6 +45,10 @@ src_prepare() {
 	#       multiple definition of `game';
 	#       /var/tmp/portage/games-roguelike/tsl-0.40-r2/temp/ccJQOSUH.o:(.bss+0x23a0):
 	#       first defined here
+	# * Force "-std=gnu17", as GCC now defaults to "-std=gnu23" where "true"
+	#   and "false" are reserved keywords. These sources define their own
+	#   "enum { false, true }", which C23 rejects with:
+	#       main.h:79:3: error: cannot use keyword 'false' as enumeration constant
 	# * Prevent squelching of build failures. *sigh*
 	# * Respect the system-wide Allegro and ncurses configurations.
 	#
@@ -55,7 +59,7 @@ src_prepare() {
 	#* Inheriting "toolchain-funcs" above.
 	#* Replacing "pkg-config" with "$(tc-getPKG_CONFIG)" below.
 	sed -i \
-		-e 's~^\(gcc.*\)\\$~\1 -fcommon \\~' \
+		-e 's~^\(gcc.*\)\\$~\1 -fcommon -std=gnu17 \\~' \
 		-e '/exit 0/d' \
 		-e 's~-lallegro -lallegro_image -lallegro_font~$(pkg-config --libs allegro-5 allegro_font-5 allegro_image-5)~' \
 		-e 's~-lcurses~$(pkg-config --libs ncurses)~' \

--- a/media-gfx/scangearmp/scangearmp-2.4.10-r1.ebuild
+++ b/media-gfx/scangearmp/scangearmp-2.4.10-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-inherit autotools udev
+inherit autotools flag-o-matic udev
 
 MY_P1=$( ver_cut 1 )
 MY_P2=$( ver_cut 2- )
@@ -38,6 +38,11 @@ QA_PREBUILT="
 
 src_prepare()
 {
+	# GCC now defaults to -std=gnu23, where "bool" is a reserved keyword.
+	# The bundled Canon headers still "typedef ... bool", which C23 rejects:
+	#   include/libcnnet2_type.h:51:14: error: 'bool' cannot be defined via 'typedef'
+	append-flags -std=gnu17
+
 	sed -i -e '/^CFLAGS/d' configure.in || die
 	sed -i -e '/AC_INIT/s/in/ac/' configure.in || die
 	mv configure.{in,ac} || die

--- a/net-print/epson-inkjet-printer_201207w/epson-inkjet-printer_201207w-1.0.0-r1.ebuild
+++ b/net-print/epson-inkjet-printer_201207w/epson-inkjet-printer_201207w-1.0.0-r1.ebuild
@@ -1,15 +1,19 @@
-# Copyright 2021-2024 Gentoo Authors
+# Copyright 2021-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
+
+# This src.rpm ships an uncompressed cpio payload; declaring it silences the
+# "rpm_unpack called without supporting app-arch/rpm" QA notice and pins a
+# proper unpack dependency. Must be set before inherit (read at global scope).
+RPM_COMPRESS_TYPE="none"
 
 inherit rpm autotools
 
 MY_PN=${PN%_*}-${PN##*_}
 
 DESCRIPTION="Epson printer driver (L110, L210, L300, L350, L355, L550, L555)"
-HOMEPAGE="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX
-	https://openprinting.github.io/foomatic/driver/epson-201207w"
+HOMEPAGE="https://openprinting.github.io/foomatic/driver/epson-201207w"
 SRC_URI="https://web.archive.org/web/20150803102803if_/http://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201207w-1.0.0-1lsb3.2.src.rpm"
 
 S="${WORKDIR}/epson-inkjet-printer-filter-${PV}"
@@ -25,10 +29,15 @@ QA_PREBUILT="
 	/opt/epson-inkjet-printer-201207w/lib64/libEpson_201207w.MT.so.1.0.0
 	/opt/epson-inkjet-printer-201207w/lib64/libEpson_201207w.so.1.0.0"
 
+# GCC 14+ rejects this 2005-era source: ten .c files call debug_msg() without
+# including its err.h declaration, and debugt_msg() returns a value from a void
+# function. The patch adds the missing includes and drops the bogus return.
+PATCHES=( "${FILESDIR}/${P}-modern-c.patch" )
+
 src_prepare() {
+	default
 	eautoreconf
 	chmod +x configure
-	eapply_user
 }
 
 src_configure() {

--- a/net-print/epson-inkjet-printer_201207w/files/epson-inkjet-printer_201207w-1.0.0-modern-c.patch
+++ b/net-print/epson-inkjet-printer_201207w/files/epson-inkjet-printer_201207w-1.0.0-modern-c.patch
@@ -1,0 +1,122 @@
+diff -ruN a/src/err.c b/src/err.c
+--- a/src/err.c	2026-07-19 23:52:30.725563534 -0000
++++ b/src/err.c	2026-07-19 23:53:21.053101006 -0000
+@@ -104,7 +104,7 @@
+ 	fflush(debug_f2);
+ 	va_end (ap);
+ #endif
+-	return 0;
++	return;
+ }
+ 
+ void
+diff -ruN a/src/filteropt/filter_option.c b/src/filteropt/filter_option.c
+--- a/src/filteropt/filter_option.c	2026-07-19 23:52:30.727387153 -0000
++++ b/src/filteropt/filter_option.c	2026-07-19 23:53:20.988371065 -0000
+@@ -16,6 +16,7 @@
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+ #include <cups/cups.h>
++#include "err.h"
+ #include "debuglog.h"
+ #include "memory.h"
+ #include "filter_option.h"
+diff -ruN a/src/main.c b/src/main.c
+--- a/src/main.c	2026-07-19 23:52:30.725442829 -0000
++++ b/src/main.c	2026-07-19 23:53:21.048364835 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <cups/cups.h>
++#include "err.h"
+ #include <cups/ppd.h>
+ #include <cups/raster.h>
+ #include <unistd.h>
+diff -ruN a/src/memory/memory.c b/src/memory/memory.c
+--- a/src/memory/memory.c	2026-07-19 23:52:30.727212141 -0000
++++ b/src/memory/memory.c	2026-07-19 23:53:20.994847627 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include "err.h"
+ #include <stdlib.h>
+ #include <string.h>
+ #include "memory.h"
+diff -ruN a/src/pagemanager/pagemanager.c b/src/pagemanager/pagemanager.c
+--- a/src/pagemanager/pagemanager.c	2026-07-19 23:52:30.725975925 -0000
++++ b/src/pagemanager/pagemanager.c	2026-07-19 23:53:21.026665126 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <string.h>
++#include "err.h"
+ 
+ #include "epcgdef.h"
+ #include "debuglog.h"
+diff -ruN a/src/pagemanager/subpagemanager.c b/src/pagemanager/subpagemanager.c
+--- a/src/pagemanager/subpagemanager.c	2026-07-19 23:52:30.725821695 -0000
++++ b/src/pagemanager/subpagemanager.c	2026-07-19 23:53:21.033331792 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include "epcgdef.h"
++#include "err.h"
+ #include "debuglog.h"
+ #include "memory.h"
+ #include "subpagemanager.h"
+diff -ruN a/src/raster/fetch-pool.c b/src/raster/fetch-pool.c
+--- a/src/raster/fetch-pool.c	2026-07-19 23:52:30.726641987 -0000
++++ b/src/raster/fetch-pool.c	2026-07-19 23:53:21.001741189 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <string.h>
++#include "err.h"
+ #include "fetch-pool.h"
+ 
+ typedef struct EpsFetchDataList {
+diff -ruN a/src/raster/raster-helper.c b/src/raster/raster-helper.c
+--- a/src/raster/raster-helper.c	2026-07-19 23:52:30.726566325 -0000
++++ b/src/raster/raster-helper.c	2026-07-19 23:53:21.006665126 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include "err.h"
+ #include <stdlib.h>
+ #include <string.h>
+ #include "memory.h"
+diff -ruN a/src/raster/raster.c b/src/raster/raster.c
+--- a/src/raster/raster.c	2026-07-19 23:52:30.726142280 -0000
++++ b/src/raster/raster.c	2026-07-19 23:53:21.021348495 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include "err.h"
+ #include <stdlib.h>
+ #include <string.h>
+ #include "raster.h"
+diff -ruN a/src/raster/scale.c b/src/raster/scale.c
+--- a/src/raster/scale.c	2026-07-19 23:52:30.726193592 -0000
++++ b/src/raster/scale.c	2026-07-19 23:53:21.013331792 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include "err.h"
+ #include <stdlib.h>
+ #include <string.h>
+ #include "memory.h"
+diff -ruN a/src/raster_to_epson.c b/src/raster_to_epson.c
+--- a/src/raster_to_epson.c	2026-07-19 23:52:30.725670311 -0000
++++ b/src/raster_to_epson.c	2026-07-19 23:53:21.041287817 -0000
+@@ -20,6 +20,7 @@
+ #endif
+ 
+ #include <stdio.h>
++#include "err.h"
+ #include <unistd.h>
+ #include <time.h>
+ #include <fcntl.h>


### PR DESCRIPTION
这几个套件在 gcc-14/16 下无法建置（见 #9141）。gcc-14 起把数个旧式 C 写法从警告升为硬错误，gcc-16 又预设 `-std=gnu23`，这些老原始码因此编译失败。

- **games-roguelike/tsl (r3)**：C23 把 `true`/`false` 变成保留字，原始码自订的 `enum { false, true }` 被拒。沿用 ebuild 既有的 sed，额外注入 `-std=gnu17`（改回 C17 语意，写法合法、无警告）。
- **media-gfx/scangearmp (r1)**：同样的 C23 问题，Canon 标头 `typedef … bool`。以 `append-flags -std=gnu17` 处理。
- **net-print/epson-inkjet-printer_201207w (r1)**：gcc-14+ 把隐式函式宣告、void 函式带回传值升为错误。加 patch 从源头修：为 10 个呼叫 `debug_msg()` 的档补上其 `err.h` 宣告、并把 `debugt_msg()`（void）里多余的 `return 0;` 改成 `return;`。另补 `RPM_COMPRESS_TYPE="none"` 消掉 rpm eclass 的 QA 提示、移除已失效的 HOMEPAGE。

测试：三个都在建置机（gcc-16/glibc-2.43）以 `ebuild clean install` 实测，皆 `Completed installing` 且 elog 无 QA Notice（epson 只余 CUPS `ppd*` deprecated 与 `fread` unused-result 两类良性警告，不触发 QA gate）；`pkgcheck scan --commits --net` 干净。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
