### PR TITLE
app-office/{wps-office,wps-office365}: add wps-office365-edu blockers, cross-reference

### DIFF
--- a/app-office/wps-office/wps-office-11.1.0.11719-r2.ebuild
+++ b/app-office/wps-office/wps-office-11.1.0.11719-r2.ebuild
@@ -31,6 +31,8 @@ BDEPEND="dev-util/patchelf"
 # The previous list was still the deps of the 2017 10.1.0.5707 rpm. Regenerate
 # with: scanelf -nBF '%n' -R office6 (then drop bundled/glibc sonames).
 RDEPEND="
+	!!app-office/wps-office365
+	!!app-office/wps-office365-edu
 	app-accessibility/at-spi2-core:2
 	app-arch/xz-utils
 	dev-db/sqlite

--- a/app-office/wps-office/wps-office-12.1.2.26885.ebuild
+++ b/app-office/wps-office/wps-office-12.1.2.26885.ebuild
@@ -14,6 +14,10 @@ S="${WORKDIR}"
 
 LICENSE="WPS-EULA"
 SLOT="0"
+# This revision is amd64-only: upstream's dogfood.gnupg.uk mirror for
+# 12.1.2.26885 only publishes an amd64 build. The older 11.1.0.11719-r2
+# revision of this package still covers arm64/loong via a different source;
+# app-office/wps-office365[-edu] also cover arm64/loong on this release line.
 KEYWORDS="~amd64"
 IUSE="systemd"
 
@@ -28,6 +32,8 @@ BDEPEND="dev-util/patchelf"
 # bundled Qt plugins and CEF, minus what is bundled under office6/. Regenerate
 # with: scanelf -nBF '%n' -R office6 (then drop bundled/glibc sonames).
 RDEPEND="
+	!!app-office/wps-office365
+	!!app-office/wps-office365-edu
 	app-accessibility/at-spi2-core:2
 	app-arch/bzip2:0
 	app-arch/xz-utils

--- a/app-office/wps-office365/wps-office365-12.1.2.26885.ebuild
+++ b/app-office/wps-office365/wps-office365-12.1.2.26885.ebuild
@@ -39,6 +39,7 @@ BDEPEND="dev-util/patchelf"
 # libraries under nplibs/ link libpulse).
 RDEPEND="
 	!!app-office/wps-office
+	!!app-office/wps-office365-edu
 	app-accessibility/at-spi2-core:2
 	app-arch/bzip2:0
 	app-arch/xz-utils
@@ -185,8 +186,12 @@ pkg_postinst() {
 	xdg_pkg_postinst
 	elog "WPS 365 opens a sign-in dialog on first launch that has no close"
 	elog "button; press Esc to dismiss it. WPS 365 may require an account, so"
-	elog "some features may be unavailable without signing in."
+	elog "some features may be unavailable without signing in. If you do not"
+	elog "want to sign in at all, app-office/wps-office365-edu (the education"
+	elog "edition) works fully without an account."
 	elog ""
 	elog "WPS 365 首次启动会弹出登入框且无关闭按钮，按 Esc 可关闭；"
 	elog "但 WPS 365 可能强制要求登入，未登入可能无法使用部分功能。"
+	elog "完全不想登入的话，可以改用 app-office/wps-office365-edu（教育版），"
+	elog "教育版不需要登入即可正常使用。"
 }


### PR DESCRIPTION
承接 #11153（app-office/wps-office365-edu 新套件），補完三個 WPS 套件的互相阻擋：之前只有 wps-office365 阻擋 wps-office，現在 wps-office 和 wps-office365 都補上阻擋 wps-office365-edu，三者共用安裝路徑，矩陣補完整。

另外兩處文字改動：
- wps-office365 的 pkg_postinst 補一句：完全不想登入的話，可以改用 app-office/wps-office365-edu（教育版），教育版不需要登入即可正常使用。
- wps-office-12.1.2.26885 加註解說明它只有 amd64（舊的 11.1.0.11719-r2 反而還有 arm64/loong，走的是不同來源）。

合併順序：這個 PR 要在 #11153 合併後才會乾淨，目前 pkgcheck 會報 3 個 NonexistentBlocker（指向還沒進 master 的 wps-office365-edu），等 #11153 合併就會消失。另外報了一個 DroppedKeywords（wps-office-12.1.2.26885 少 arm64/loong），這是既有狀態、跟這次改動無關（diff 沒動 KEYWORDS 那行），正好就是新增註解在說明的事。

純加 RDEPEND blocker 跟文字（elog/註解），沒改安裝邏輯，沒有重新 emerge 逐版測試，先開 draft。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.