### PR TITLE
autobump: opt in bun-bin + libzim, disable apifox opt-in

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -57,6 +57,7 @@ source = "github"
 github = "openzim/libzim"
 use_latest_release = true
 github_account = ["liangyongxiang", "gouwazi"]
+autobump = true
 
 ["app-backup/restic-rest-server"]
 source = "github"
@@ -1759,6 +1760,7 @@ github = "oven-sh/bun"
 use_latest_release = true
 prefix = "bun-v"
 github_account = "douglarek"
+autobump = true
 
 # live package only
 #["net-libs/jzmq"]
@@ -1794,7 +1796,8 @@ source = "regex"
 url = "https://api.apifox.com/api/v1/configs/client-updates/2/mac/latest-mac.yml"
 regex = 'version: (.*)'
 github_account = ["gouwazi"]
-autobump = true
+# autobump off: Cloudflare blocks the download UA (fetches the CF challenge
+# page instead of the .deb, so the payload looks changed) — needs a manual bump.
 
 ["net-misc/baidunetdisk"]
 source = "regex"


### PR DESCRIPTION
## 原因
- **net-libs/bun-bin**、**app-arch/libzim** 歷史高比例機械 bump(#11143 A 段:bun-bin 100%、libzim 83%),加 `autobump`。libzim 是函式庫,遇 soname/subslot bump 會 escalate 走人工,安全。
- **net-misc/apifox** 關掉 `autobump`:Cloudflare 擋下載 UA,抓到的是 CF 攔截頁不是 `.deb`,payload 每次都「變」→ 每版 escalate。備註留在 toml,需手動 bump。

## 測試
只改 nvchecker `overlay.toml` 的 opt-in 標記,不動任何 ebuild。
