### PR TITLE
autobump: raise op-timeout so nodejs can build from source

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -52,9 +52,10 @@ jobs:
   sweep:
     if: github.repository == 'gentoo-zh/overlay' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # limit(3) x AUTOBUMP_OP_TIMEOUT(2700s=45min)=135min worst case + ~10min setup; keep the
-    # job ceiling above it so a tail of heavy from-source builds is not cut off mid-run.
-    timeout-minutes: 150
+    # A heavy from-source dep (e.g. net-libs/nodejs for the pnpm/npm family) can take ~1h+; give the
+    # per-op ceiling (AUTOBUMP_OP_TIMEOUT below) room for it and keep this job ceiling above one such
+    # build plus a tail of light packages, so a heavy build finishes instead of being cut off mid-run.
+    timeout-minutes: 200
     container:
       image: gentoo/stage3:amd64-desktop-openrc
       options: --privileged
@@ -181,9 +182,9 @@ jobs:
         # /__w/..., so an absolute host path does not exist inside the container. The sweep
         # cd's into the overlay (= the workspace), so a path relative to it always resolves.
         AUTOBUMP_ENGINE: ruby autobump-rb/bin/autobump
-        # the job has 90 min and --limit 3, so allow a generous per-op ceiling -
-        # a heavy from-source build should finish, not time out and defer.
-        AUTOBUMP_OP_TIMEOUT: '2700'
+        # allow a generous per-op ceiling so a heavy from-source build (net-libs/nodejs ~1h)
+        # finishes instead of timing out and deferring; keep in step with timeout-minutes above.
+        AUTOBUMP_OP_TIMEOUT: '7200'
         # pin the state dir to match the cache path above: in a container job HOME is
         # /github/home (not /root), so the default $HOME/.local/state would diverge from
         # the cached /root/.local/state and done.list would never persist across runs.


### PR DESCRIPTION
## 原因
搭配 **autobump-rb#2**(nodejs 移出 HEAVY)。讓 autobump sweep 的 build_test 有足夠時間從源碼編 nodejs(~1h),pnpm 等 npm 家族不再被 defer。

- `AUTOBUMP_OP_TIMEOUT` 2700s(45min)→ 7200s(120min):單次 emerge 上限,夠 nodejs 編完。
- job `timeout-minutes` 150 → 200:容一次重型編譯 + 其餘輕包,不中途砍斷。

## 配套
需 autobump-rb#2 一起合才完整;在那之前 pnpm 仍安全 defer。

## 測試
只改 workflow timeout 值,YAML 有效。nodejs 從源碼編在 CI 可行,已由 pnpm PR #11163 的 emerge-on-pr(無 timeout gate)實測進行中。
