### PR TITLE
autobump: enable the weekly recommend cron

### DIFF
--- a/.github/workflows/autobump-recommend.yml
+++ b/.github/workflows/autobump-recommend.yml
@@ -20,9 +20,10 @@
 name: autobump-recommend
 
 on:
-  # weekly, disabled for the initial rollout: run manually first, then uncomment.
-  # schedule:
-  #   - cron: '0 6 * * 1'
+  # weekly recommendation scan (Monday 06:00 UTC). Recommendation-only -- opens no PRs, just
+  # refreshes the single fixed issue in place; a maintainer still opts packages in by hand.
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       probe_limit:


### PR DESCRIPTION

recommend 掃描(自動檢測可 opt-in 的候選)之前 cron 註解掉、只能手動觸發,所以 #11143 會過時。打開每週一 06:00 UTC 的排程,自動刷新推薦。
