### PR TITLE
autobump: don't recommend packages turned off with '# autobump off'

### DIFF
--- a/scripts/autobump-discover.sh
+++ b/scripts/autobump-discover.sh
@@ -25,19 +25,23 @@ TOML=.github/workflows/overlay.toml
 # for amd64+arm64) are NOT bundles and must not match, so this is a suffix allowlist, not a count.
 BUNDLE_RE='(-vendor|-crates|-deps|-pubcache|-vcpkg|-gomod|-go-mod|-cargo|-web|node_modules)'
 
-already_on() {  # already whitelisted with autobump = true?
-    # strip an inline comment after the table header (`["cat/pkg"] # note` is valid TOML)
-    # so a commented-header package isn't re-recommended as if it were never whitelisted.
+excluded() {  # already decided -- whitelisted (autobump = true) OR deliberately disabled (# autobump off)
+    # strip an inline comment after the table header (`["cat/pkg"] # note` is valid TOML) so a
+    # commented-header package isn't re-recommended as if never whitelisted; and a package a
+    # maintainer explicitly turned off (e.g. `# autobump off: Cloudflare ...`) stays off, not re-surfaced.
     awk -v w="[\"$1\"]" '
         {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
-        h==w{f=1;next}/^\[/{f=0}f&&/autobump = true/{e=1}END{exit !e}' "$TOML" 2>/dev/null
+        h==w{f=1;next}/^\[/{f=0}
+        f&&/autobump = true/{e=1}
+        f&&/#[[:space:]]*autobump[[:space:]]+off/{e=1}
+        END{exit !e}' "$TOML" 2>/dev/null
 }
 
 # every package with an "add ..." bump commit in the window
 git log "$REF" --oneline -"$N" --no-merges 2>/dev/null \
   | grep -oE '[a-z0-9-]+/[A-Za-z0-9_.+-]+: add ' | sed 's/: add //' | sort -u \
   | while read -r pkg; do
-    already_on "$pkg" && continue
+    excluded "$pkg" && continue
     total=0 mech=0
     for sha in $(git log "$REF" --oneline -"$N" -- "$pkg" 2>/dev/null | grep ': add ' | awk '{print $1}'); do
         total=$((total + 1))

--- a/scripts/autobump-probe.sh
+++ b/scripts/autobump-probe.sh
@@ -40,6 +40,13 @@ autobump_enabled() {
         .github/workflows/overlay.toml
 }
 
+autobump_disabled() {  # a maintainer explicitly turned it off (`# autobump off: ...`) -- never recommend it
+    awk -v want="[\"$1\"]" '
+        {h=$0; sub(/[[:space:]]*#.*/,"",h); gsub(/[[:space:]]+$/,"",h)}
+        h==want{f=1;next}/^\[/{f=0}f&&/#[[:space:]]*autobump[[:space:]]+off/{e=1}END{exit !e}' \
+        .github/workflows/overlay.toml
+}
+
 if ! raw=$(gh issue list --repo "$UPSTREAM_REPO" --search '[nvchecker] in:title' \
     --state open --json number --jq '.[].number'); then
     echo "gh issue list failed (auth/rate-limit/network?)" >&2; exit 2
@@ -54,6 +61,7 @@ for n in "${ISSUES[@]}"; do
     pkg=$(sed -nE 's/^\[nvchecker\] ([a-z0-9-]+\/[A-Za-z0-9_.+-]+) can be bump to .*/\1/p' <<<"$title")
     ver=$(sed -nE 's/.* can be bump to ([A-Za-z0-9._+-]+)$/\1/p' <<<"$title")
     [ -n "$pkg" ] && [ -n "$ver" ] || continue
+    autobump_disabled "$pkg" && continue    # deliberately off -- keep it out of the recommendation
     tag=""; autobump_enabled "$pkg" && tag=" [opted-in]"
 
     $ENGINE "$n" --check >/dev/null 2>&1; ec=$?


### PR DESCRIPTION
## 原因
recommend 只看「沒 opt-in + 歷史機械」就推薦,**不知道有些包是維護者故意關掉的**。例如 net-misc/apifox 因 Cloudflare 擋 UA 被 #11161 停用(toml 裡留了 `# autobump off:` 備註),卻又被 A 段當 92% 機械重新推薦——cron 一開會每週刷屏。

## 改動
- discover:`already_on` → `excluded`,block 裡有 `# autobump off` 也視為「已決定、排除」。
- probe:加 `autobump_disabled`,迴圈直接跳過故意關的。

任何有 `# autobump off` 標記的包從此不再被推薦。

## 測試
`bash -n` 兩支;`excluded()` 單元測(apifox/opted-in → 排除,未加的 → 仍可推薦);實跑 discover 確認 apifox 消失、chezmoi/v2ray(註解掉的)照舊。
