### PR TITLE
autobump: disable vintagestory (large download times out in CI)

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1229,7 +1229,8 @@ source = "regex"
 url = "https://api.vintagestory.at/lateststable.txt"
 regex = "([\\d.]+)"
 github_account = "liuyujielol"
-autobump = true
+# autobump off: the ~590 MB game tarball from cdn.vintagestory.at is slow in CI and the emerge
+# times out; bump it on the build box instead (fast link + a warm distfile cache).
 
 ["games-arcade/osu-lazer-bin"]
 source = "github"


### PR DESCRIPTION
因为 games-action/vintagestory 的游戏包约 590 MB，从 cdn.vintagestory.at 拉取在 CI 里慢、emerge 超时，所以关闭它的 autobump，改在 build box 上手动 bump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
