### PR TITLE
autobump: disable codex, reeknote, tsshd (vendor-regen, not mechanical)

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -122,7 +122,7 @@ source = "github"
 github = "vitaly-zdanevich/reeknote"
 use_latest_release = true
 github_account = "vitaly-zdanevich"
-autobump = true
+# autobump off: the per-version vendor bundle must be regenerated first -- not a mechanical bump.
 
 ["app-editors/antigravity"]
 source = "regex"
@@ -1054,7 +1054,8 @@ github = "openai/codex"
 use_latest_release = true
 prefix = "rust-v"
 github_account = "vowstar"
-autobump = true
+# autobump off: Rust crates + GIT_CRATES + rusty_v8 vendor bundles are regenerated per version
+# (gentoo-zh-drafts/codex crates.yml) and the ebuild changes each bump -- not a mechanical bump.
 
 ["dev-util/gitea-cli"]
 source = "gitea"
@@ -1957,7 +1958,7 @@ github = "trzsz/tsshd"
 use_latest_release = true
 prefix = "v"
 github_account = "locez"
-autobump = true
+# autobump off: the per-version vendor bundle must be regenerated first -- not a mechanical bump.
 
 ["net-misc/yaak-bin"]
 source = "github"


### PR DESCRIPTION
因为 dev-util/codex、app-doc/reeknote、net-misc/tsshd 都带按版本重新生成的 vendor/crates 束（codex 另有 GIT_CRATES 和 rusty_v8），新版本要先另行生成该束、ebuild 也随之改动，不是机械 rename，autobump 只会 404 或 escalate，所以关闭它们的 autobump，改为手动 bump。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
