### PR TITLE
autobump: finalize the status comment when already at target

### DIFF
--- a/scripts/autobump-sweep.sh
+++ b/scripts/autobump-sweep.sh
@@ -248,6 +248,9 @@ for n in "${ISSUES[@]}"; do
         if grep -qE 'already at|already exists|would downgrade|newer than target' <<<"$out"; then
             echo "$pkg $ver done-precondition $(date +%F)" >> "$DONE"
             RESULT[$n]="done (precondition: overlay already at/ahead of $ver)"
+            # overlay already has this version or newer (a stale nvchecker issue); replace the
+            # "is bumping…" comment with a terminal note so it does not read as stuck forever.
+            status_comment "$n" "**autobump**: \`$pkg\` is already at (or ahead of) \`$ver\` in the overlay — nothing to bump.$(run_link)"
         else
             # genuine transient (dirty tree, fetch flake, emerge timeout, dep-resolution gap):
             # retry next sweep, but CAP retries so it eventually reaches a human.


### PR DESCRIPTION
因为过时的 nvchecker issue（树上已是目标版本或更新）走 precondition-skip 时不更新已发出的「is bumping…」评论，维护者会看到它永远停在「处理中」，所以在 precondition 分支把评论改成「已是最新、无需 bump」的终态。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
