### PR TITLE
dev-util/reasonix-bin: update maintainers

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1190,7 +1190,7 @@ github = "esengine/DeepSeek-Reasonix"
 use_max_release = true
 include_regex = "v\\d+\\.\\d+\\.\\d+"
 prefix = "v"
-github_account = "xz-dev"
+github_account = "wgjak47"
 autobump = true
 
 ["dev-util/redpanda-cpp"]

--- a/dev-util/reasonix-bin/metadata.xml
+++ b/dev-util/reasonix-bin/metadata.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>xiangzhedev@gmail.com</email>
-		<name>xz-dev</name>
+		<email>ak47m61@gmail.com</email>
+		<name>wgjak47</name>
 	</maintainer>
 	<upstream>
 		<remote-id type="github">esengine/DeepSeek-Reasonix</remote-id>


### PR DESCRIPTION
把维护者从误挂的 xz-dev（xiangzhedev@gmail.com）改为实际添加此包的 wgjak47（ak47m61@gmail.com），overlay.toml 的 github_account 一并改为 wgjak47。Closes #11262

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.