### PR TITLE
.github/workflows: skip online key refresh during tree sync

### DIFF
--- a/.github/workflows/autobump-recommend.yml
+++ b/.github/workflows/autobump-recommend.yml
@@ -58,7 +58,20 @@ jobs:
       built: ${{ steps.trial.outputs.built }}
     steps:
       - name: sync gentoo main tree
-        run: emerge-webrsync
+        # emerge-webrsync has gemato refresh the release keys from a keyserver/WKD
+        # before verifying the snapshot; with neither reachable the sync aborts even
+        # though the stage3 image already ships valid gentoo-release keys. Shim gemato
+        # with -R so it still verifies against those local keys but skips the online
+        # refresh (whose only purpose is catching revocation).
+        run: |
+          shim=$(mktemp -d)
+          cat > "$shim/gemato" <<'SH'
+          #!/bin/sh
+          [ "$1" = openpgp-verify-detached ] && { shift; set -- openpgp-verify-detached -R "$@"; }
+          exec /usr/bin/gemato "$@"
+          SH
+          chmod +x "$shim/gemato"
+          PATH="$shim:$PATH" emerge-webrsync
 
       - name: setup portage
         run: |

--- a/.github/workflows/autobump-selftest.yml
+++ b/.github/workflows/autobump-selftest.yml
@@ -18,7 +18,20 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      # emerge-webrsync has gemato refresh the release keys from a keyserver/WKD
+      # before verifying the snapshot; with neither reachable the sync aborts even
+      # though the stage3 image already ships valid gentoo-release keys. Shim gemato
+      # with -R so it still verifies against those local keys but skips the online
+      # refresh (whose only purpose is catching revocation).
+      run: |
+        shim=$(mktemp -d)
+        cat > "$shim/gemato" <<'SH'
+        #!/bin/sh
+        [ "$1" = openpgp-verify-detached ] && { shift; set -- openpgp-verify-detached -R "$@"; }
+        exec /usr/bin/gemato "$@"
+        SH
+        chmod +x "$shim/gemato"
+        PATH="$shim:$PATH" emerge-webrsync
 
     - name: setup portage
       run: |

--- a/.github/workflows/autobump-trial.yml
+++ b/.github/workflows/autobump-trial.yml
@@ -38,7 +38,20 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      # emerge-webrsync has gemato refresh the release keys from a keyserver/WKD
+      # before verifying the snapshot; with neither reachable the sync aborts even
+      # though the stage3 image already ships valid gentoo-release keys. Shim gemato
+      # with -R so it still verifies against those local keys but skips the online
+      # refresh (whose only purpose is catching revocation).
+      run: |
+        shim=$(mktemp -d)
+        cat > "$shim/gemato" <<'SH'
+        #!/bin/sh
+        [ "$1" = openpgp-verify-detached ] && { shift; set -- openpgp-verify-detached -R "$@"; }
+        exec /usr/bin/gemato "$@"
+        SH
+        chmod +x "$shim/gemato"
+        PATH="$shim:$PATH" emerge-webrsync
 
     - name: setup portage
       run: |

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -62,7 +62,20 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      # emerge-webrsync has gemato refresh the release keys from a keyserver/WKD
+      # before verifying the snapshot; with neither reachable the sync aborts even
+      # though the stage3 image already ships valid gentoo-release keys. Shim gemato
+      # with -R so it still verifies against those local keys but skips the online
+      # refresh (whose only purpose is catching revocation).
+      run: |
+        shim=$(mktemp -d)
+        cat > "$shim/gemato" <<'SH'
+        #!/bin/sh
+        [ "$1" = openpgp-verify-detached ] && { shift; set -- openpgp-verify-detached -R "$@"; }
+        exec /usr/bin/gemato "$@"
+        SH
+        chmod +x "$shim/gemato"
+        PATH="$shim:$PATH" emerge-webrsync
 
     - name: setup portage
       run: |

--- a/.github/workflows/emerge-on-pr.yml
+++ b/.github/workflows/emerge-on-pr.yml
@@ -112,7 +112,20 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      # emerge-webrsync has gemato refresh the release keys from a keyserver/WKD
+      # before verifying the snapshot; with neither reachable the sync aborts even
+      # though the stage3 image already ships valid gentoo-release keys. Shim gemato
+      # with -R so it still verifies against those local keys but skips the online
+      # refresh (whose only purpose is catching revocation).
+      run: |
+        shim=$(mktemp -d)
+        cat > "$shim/gemato" <<'SH'
+        #!/bin/sh
+        [ "$1" = openpgp-verify-detached ] && { shift; set -- openpgp-verify-detached -R "$@"; }
+        exec /usr/bin/gemato "$@"
+        SH
+        chmod +x "$shim/gemato"
+        PATH="$shim:$PATH" emerge-webrsync
 
     - name: fetch repo
       uses: actions/checkout@v7

--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -25,8 +25,20 @@ jobs:
       pkgs: ${{ steps.eix.outputs.pkgs }}
     steps:
     - name: sync gentoo main tree
+      # emerge-webrsync has gemato refresh the release keys from a keyserver/WKD
+      # before verifying the snapshot; with neither reachable the sync aborts even
+      # though the stage3 image already ships valid gentoo-release keys. Shim gemato
+      # with -R so it still verifies against those local keys but skips the online
+      # refresh (whose only purpose is catching revocation).
       run: |
-        emerge-webrsync
+        shim=$(mktemp -d)
+        cat > "$shim/gemato" <<'SH'
+        #!/bin/sh
+        [ "$1" = openpgp-verify-detached ] && { shift; set -- openpgp-verify-detached -R "$@"; }
+        exec /usr/bin/gemato "$@"
+        SH
+        chmod +x "$shim/gemato"
+        PATH="$shim:$PATH" emerge-webrsync
 
     - name: cat binrepos
       run: |


### PR DESCRIPTION
因为 emerge-webrsync 会让 gemato 先从 keyserver/WKD 在线刷新 gentoo-release 密钥再验签、keyserver 不通时整步 sync 就失败（经常因此闪红）；给 gemato 加 `-R` 跳过在线刷新即可，仍用 stage3 镜像内建的密钥完成签章验证，不影响安全性。

刷新的唯一作用是查密钥撤销，跳过它是安全的：镜像约每周重建、内建密钥始终是当前的，且密钥有效期到 2028-07-01。
<img width="1280" height="240" alt="image" src="https://github.com/user-attachments/assets/12027ae6-9d64-4ecc-a997-b997471f7ee9" />

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
