### PR TITLE
net-im/tencent-qq: fix nvchecker version source

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1788,10 +1788,10 @@ regex = 'com.alibabainc.dingtalk_(.*)_amd64.deb'
 github_account = "gouwazi"
 
 ["net-im/tencent-qq"]
-source = "regex"
-url = "https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/linuxConfig.js"
-regex = 'QQ_([\d\.\_]+)_.*.deb'
-from_pattern = '(.*)_(.*)'
+# QQ doesn't publish the build number (e.g. 51102) anywhere fetchable, so track updates via AUR's linuxqq.
+source = "aur"
+aur = "linuxqq"
+from_pattern = '\d+:([\d.]+)_(\d+)-\d+'
 to_pattern = '\1_p\2'
 github_account = ["Puqns67", "gouwazi"]
 


### PR DESCRIPTION
nvchecker 原先从 linuxConfig.js 的 .deb 文件名抓到的是发布日期(如 260710),不是 QQ 的 build 号(51102),因为 260710 > 51102 一直误报可升级到 p260710。

QQ 不在任何网页/config 公开 build 号,只有 AUR 的 linuxqq 一直维护着。改用内建 `source = "aur"`(与本仓 wemeet、unityhub、jetbrains-toolbox 等同款写法),取其 pkgver 3.2.31_51102,去掉 epoch 与 pkgrel、把 _ 转成 _p,得到 `3.2.31_p51102`(与 ebuild 一致)。已用 nvchecker 实测。Closes #11292

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.