### PR TITLE
.github: run emerge-webrsync with --no-pgp-verify

### DIFF
--- a/.github/workflows/autobump-recommend.yml
+++ b/.github/workflows/autobump-recommend.yml
@@ -58,7 +58,7 @@ jobs:
       built: ${{ steps.trial.outputs.built }}
     steps:
       - name: sync gentoo main tree
-        run: emerge-webrsync
+        run: emerge-webrsync --no-pgp-verify
 
       - name: setup portage
         run: |

--- a/.github/workflows/autobump-selftest.yml
+++ b/.github/workflows/autobump-selftest.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      run: emerge-webrsync --no-pgp-verify
 
     - name: setup portage
       run: |

--- a/.github/workflows/autobump-trial.yml
+++ b/.github/workflows/autobump-trial.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      run: emerge-webrsync --no-pgp-verify
 
     - name: setup portage
       run: |

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      run: emerge-webrsync --no-pgp-verify
 
     - name: setup portage
       run: |

--- a/.github/workflows/emerge-on-pr.yml
+++ b/.github/workflows/emerge-on-pr.yml
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: sync gentoo main tree
-      run: emerge-webrsync
+      run: emerge-webrsync --no-pgp-verify
 
     - name: fetch repo
       uses: actions/checkout@v7

--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: sync gentoo main tree
       run: |
-        emerge-webrsync
+        emerge-webrsync --no-pgp-verify
 
     - name: cat binrepos
       run: |


### PR DESCRIPTION
emerge-webrsync 默认用 gemato 验证 snapshot 的 PGP 签名,而 gemato 会从 keyserver 拉取/刷新 gentoo 发布 key,这一步在 CI 里慢且偶尔 flaky(keyserver 不稳时整个 job 卡住)。

加 `--no-pgp-verify` 后 verification_method 置空、gemato 不再执行,不再碰 keyserver;树仍走 HTTPS 从官方 mirror 同步。对 ephemeral 的 CI 容器这是合理取舍,gentoo/prefix 的 bootstrap 也是这么做的(gentoo/prefix@5361ab3)。改动覆盖所有用到 emerge-webrsync 的 workflow(emerge-on-pr、nvchecker、autobump 系列)。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.