### PR TITLE
.github/workflows/nvchecker: auto-dispatch on-demand deps generators

### DIFF
--- a/.github/workflows/gentoo-deps-dispatcher.toml
+++ b/.github/workflows/gentoo-deps-dispatcher.toml
@@ -1,0 +1,65 @@
+# Packages whose Cargo/pub/node/go dependencies are vendored into a bundle by
+# gentoo-zh/gentoo-deps (generator.yml). The deps-dispatch job in nvchecker.yml
+# fires that generator via gentoo-zh/deps-dispatcher when a new version is
+# detected, so the bundle is ready before autobump.
+#
+# The dispatched bundle is what autobump hashes into the ebuild Manifest, so it
+# need not match any previously published bundle. go (vendor) and rust (crates)
+# bundles are byte-reproducible for a given tag; dart (pub-cache) and node
+# (node_modules) are re-resolved each run and can differ file-for-file from an
+# older bundle while still pinning the same locked versions.
+#
+# Templates in tag/workdir/vendordir: {PV}=version, {PN}=package name (no
+# category), {P}={PN}-{PV}. vendordir is the ebuild S that vendor/ sits under;
+# only golang uses it.
+#
+# Every other on-demand package is left manual on purpose:
+#   gitea-cli   upstream is on gitea.com; generator.yml only takes a GitHub repo,
+#               so it cannot fetch this one.
+#   nali        the ebuild pins a commit snapshot (0.8.1_pYYYYMMDD), not an
+#               upstream tag, so nvchecker has no version event to fire on.
+#   rustdesk,   their flutter-deps bundle comes from a per-app generator, not
+#   localsend   gentoo-deps; handled in those repositories.
+
+[[package]]
+name = "app-crypt/cotp"
+lang = "rust"
+repo = "replydev/cotp"
+tag  = "v{PV}"
+
+[[package]]
+name = "dev-util/fvm"
+lang = "dart"
+repo = "leoafarias/fvm"
+tag  = "{PV}"
+
+[[package]]
+name = "net-dns/ddns-go"
+lang = "golang"
+repo = "jeessy2/ddns-go"
+tag  = "v{PV}"
+vendordir = "{P}"
+
+[[package]]
+name = "net-proxy/zashboard"
+lang = "javascript"
+repo = "Zephyruso/zashboard"
+tag  = "v{PV}"
+
+# v2rayA: two Go modules (service + core) with separate go.mod, so two sub-bundles.
+# Both vendor under the same ebuild S (v2rayA-${PV}); the module is a subdir of it.
+[[package]]
+name = "net-proxy/v2rayA"
+lang = "golang"
+repo = "v2rayA/v2rayA"
+tag  = "v{PV}"
+
+  [[package.module]]
+  p = "v2rayA-service-{PV}"
+  workdir = "service"
+  vendordir = "{P}/service"
+
+  [[package.module]]
+  p = "v2rayA-core-{PV}"
+  workdir = "core"
+  vendordir = "{P}/core"

--- a/.github/workflows/nvchecker.yml
+++ b/.github/workflows/nvchecker.yml
@@ -138,3 +138,37 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GENTOO_ZH_NVCHECKER_PAT }} # https://github.com/gentoo-zh/overlay/pull/3130
       run: |
         go run . --file gentoo-zh/.github/workflows/overlay.toml --name "$name" --newver "$newver" --oldver "$oldver"
+
+  # For packages whose vendor/deps bundle is generated on demand (see
+  # gentoo-zh/deps-dispatcher/config.toml), fire the gentoo-deps generator
+  # as soon as a new version is detected, so the bundle is ready before autobump.
+  deps-dispatch:
+    needs: nvchecker
+    if: needs.nvchecker.outputs.nvcmp != '[]'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout deps-dispatcher
+      uses: actions/checkout@v7
+      with:
+        repository: 'gentoo-zh/deps-dispatcher'
+
+    - name: Checkout gentoo-zh
+      uses: actions/checkout@v7
+      with:
+        path: 'gentoo-zh'
+
+    - name: Get a token that can dispatch gentoo-deps
+      uses: actions/create-github-app-token@v3
+      id: app-token
+      with:
+        client-id: ${{ secrets.DRAFTS_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.DRAFTS_BOT_PRIVATE_KEY }}
+        owner: gentoo-zh
+        repositories: gentoo-deps
+
+    - name: Dispatch generators for new versions
+      timeout-minutes: 5
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        NVCMP: ${{ needs.nvchecker.outputs.nvcmp }}
+      run: echo "$NVCMP" | python3 dispatch.py --config gentoo-zh/.github/workflows/gentoo-deps-dispatcher.toml --run


### PR DESCRIPTION
少數包的 vendor/deps bundle 需按需生成,目前得手動觸發 gentoo-deps 的 generator。新增 deps-dispatch
job:nvchecker 偵測到新版就自動 workflow_dispatch generator(bundle 已存在則跳過)。納入哪些包、留手動
的原因,見 gentoo-zh/deps-dispatcher 的 config.toml。

合併前把 gentoo-zh-drafts-bot 的 client-id / private-key 存成 secret
DRAFTS_BOT_CLIENT_ID / DRAFTS_BOT_PRIVATE_KEY(它對 gentoo-zh/gentoo-deps 有 actions:write)。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
