### PR TITLE
.github/workflows/overlay.toml: fix broken nvchecker version sources

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -688,13 +688,13 @@ github_account = ["zozx", "gouwazi"]
 ["app-office/wps-office"]
 source = "regex"
 url = "https://linux.wps.cn/wpslinuxlog"
-regex = "wps-office_([\\d.]+)_amd64.deb"
+regex = 'wps-office_([\d.]+)\.'
 github_account = ["Universebenzene", "gouwazi", "zakkaus"]
 
 ["app-office/wps-office365"]
 source = "regex"
 url = "https://linux.wps.cn/wpslinuxlog"
-regex = "wps-office_([\\d.]+)_amd64.deb"
+regex = 'wps-office_([\d.]+)\.'
 github_account = ["Universebenzene", "gouwazi", "zakkaus"]
 
 # The edu channel has no version-log page like linux.wps.cn/wpslinuxlog; piggyback
@@ -1209,7 +1209,7 @@ github_account = "liangyongxiang"
 ["dev-util/trae-ide"]
 source = "regex"
 url = "https://api.trae.cn/icube/api/v1/native/version/trae/cn/latest"
-regex = '"linux":\{"version":"([\d.]+)"'
+regex = 'releases/stable/([\d.]+)/'
 github_account = "microcai"
 
 ["dev-util/vcpkg-tool"]
@@ -1996,7 +1996,7 @@ github_account = "gouwazi"
 ["net-misc/todesk"]
 source = "regex"
 url = "https://www.todesk.com/linux.html"
-regex = "todesk-v(.*)-amd64.deb"
+regex = 'todesk-v([\d.]+)-amd64\.deb'
 github_account = ["microcai", "gouwazi"]
 
 ["net-misc/tsshd"]
@@ -2183,7 +2183,7 @@ github_account = ["liuyujielol", "Zakkaus"]
 ["net-proxy/Xray"]
 source = "github"
 github = "XTLS/Xray-core"
-use_latest_release = true
+use_max_tag = true
 prefix = "v"
 
 ["net-proxy/yacd-meta"]


### PR DESCRIPTION
todesk 的 regex 用 greedy `.*`,把整段 JS 都吞进版本号,改成 `([\d.]+)` 只取版本。
wps-office 与 wps-office365 的 deb 文件名新增了 `.AK.preread…` 后缀,旧 regex 匹配不到,改用 `wps-office_([\d.]+)\.`。
trae-ide 的接口结构变了、不再有 `"linux":{"version"`,改从下载 URL 的 `releases/stable/([\d.]+)/` 取版本。
Xray 的 `use_latest_release` 抓到被标为 latest 的旧版 v26.3.27(倒退),改用 `use_max_tag` 取最高 tag。
以上四处都用 nvchecker 实测确认解析正确。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.