### PR TITLE
net-proxy/v2rayA: build the bundled core in 9999

### DIFF
--- a/net-proxy/v2rayA/v2rayA-9999.ebuild
+++ b/net-proxy/v2rayA/v2rayA-9999.ebuild
@@ -12,18 +12,16 @@ EGIT_REPO_URI="https://github.com/v2rayA/v2rayA.git"
 EGIT_BRANCH="main" # HEAD
 
 LICENSE="AGPL-3"
+# statically linked Go deps; core is a fork of xtls/xray-core (MPL-2.0)
+LICENSE+=" Apache-2.0 BSD BSD-2 GPL-3+ LGPL-3 MIT MPL-2.0"
 SLOT="0"
-IUSE="xray"
 
 RDEPEND="
-	|| (
-		>=net-proxy/v2ray-5
-		>=net-proxy/v2ray-bin-5
-	)
-	xray? ( net-proxy/Xray )
+	app-alternatives/v2ray-geoip
+	app-alternatives/v2ray-geosite
 "
 BDEPEND="
-	>=dev-lang/go-1.21:*
+	>=dev-lang/go-1.26:*
 	>=net-libs/nodejs-16
 	sys-apps/yarn
 "
@@ -31,14 +29,15 @@ BDEPEND="
 src_unpack() {
 	git-r3_src_unpack
 
-	# requires network
+	# The live ebuild has no pre-generated web/vendor bundles; fetch the web
+	# deps and vendor both Go modules (service and core) from the network.
 	cd "${S}/gui" || die
-	#yarn config set registry https://registry.npmmirror.com || die
 	yarn install --ignore-engines --check-files || die "yarn install failed"
 
-	# requires network
 	cd "${S}/service" || die
-	#ego env -w GOPROXY=https://goproxy.cn,direct
+	ego mod vendor
+
+	cd "${S}/core" || die
 	ego mod vendor
 }
 
@@ -50,27 +49,40 @@ src_compile() {
 	fi
 	OUTPUT_DIR="${S}/service/server/router/web" yarn build || die "yarn build failed"
 
+	# v2rayA 2.4.6+ ships its own core (a fork of xray-core with the
+	# MultiObservatory patches) instead of calling an external v2ray/xray.
+	cd "${S}/core" || die
+	ego build -mod=vendor -trimpath \
+		-ldflags "-X main.Version=${PV}" \
+		-o v2raya_core ./main
+
 	cd "${S}/service" || die
-	ego build -mod vendor -tags "with_gvisor" -ldflags "-X github.com/v2rayA/v2rayA/conf.Version=${PV}" -o v2raya
+	ego build -mod=vendor -tags "with_gvisor" \
+		-ldflags "-X github.com/v2rayA/v2rayA/conf.Version=${PV}" \
+		-o v2raya -trimpath
 }
 
 src_install() {
 	dobin "${S}"/service/v2raya
-	# directory for runtime use
+	dobin "${S}"/core/v2raya_core
+
+	# v2rayA looks for geodata in /usr/share/v2raya/; point it at the files
+	# installed by app-alternatives/v2ray-geoip and v2ray-geosite.
+	dosym -r /usr/share/v2ray/geoip.dat /usr/share/v2raya/geoip.dat
+	dosym -r /usr/share/v2ray/geosite.dat /usr/share/v2raya/geosite.dat
+
 	keepdir "/etc/v2raya"
 
 	./service/v2raya --report config | sed '1,6d' | fold -s -w 78 | sed -E 's/^([^#].+)/# \1/'\
 		>> "${S}"/install/universal/v2raya.default || die
 
-	# config /etc/default/v2raya
 	insinto "/etc/default"
 	newins "${S}"/install/universal/v2raya.default v2raya
 
 	systemd_dounit "${S}"/install/universal/v2raya.service
 	systemd_douserunit "${S}"/install/universal/v2raya-lite.service
 
-	#thanks to @Universebenzene
-	newinitd "${FILESDIR}/${PN}.initd" v2raya
+	newinitd "${FILESDIR}/${PN}.initd-r1" v2raya
 	newinitd "${FILESDIR}/${PN}-user.initd" v2raya-user
 	newconfd "${FILESDIR}/${PN}.confd" v2raya
 	newconfd "${FILESDIR}/${PN}-user.confd" v2raya-user
@@ -82,9 +94,9 @@ src_install() {
 pkg_postinst() {
 	xdg_pkg_postinst
 
-	if has_version '<net-proxy/v2rayA-2.0.0' ; then
-		elog "Starting from net-proxy/v2rayA-2.0.0"
-		elog "Support for v2ray-4 has been dropped"
-		elog "A config migration may be required"
+	if has_version '<net-proxy/v2rayA-2.4.6' ; then
+		elog "2.4.6 bundles its own v2raya_core binary (a fork of xray-core)."
+		elog "net-proxy/v2ray and net-proxy/v2ray-bin are no longer required"
+		elog "by v2rayA. You may remove them if not needed by other packages."
 	fi
 }


### PR DESCRIPTION
上游 2.4.6 起自带核心(v2raya_core,xray-core 的 fork),不再调用外部 v2ray/xray。9999 还停在旧的外部核心模型,这里对齐 2.4.9:构建并安装 v2raya_core、去掉外部 v2ray/xray 依赖与 xray USE。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.