### PR TITLE
.github/workflows/overlay.toml: opt kiro, kiro-cli, antigravity-cli, copilot into autobump

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -161,6 +161,7 @@ source = "regex"
 url = "https://kiro.dev/downloads/"
 regex = 'signed/([\d.]+)/tar'
 github_account = "zakkaus"
+autobump = true
 
 ["app-editors/void-editor"]
 source = "github"
@@ -196,6 +197,7 @@ github = "github/copilot-cli"
 use_latest_release = true
 prefix = "v"
 github_account = "douglarek"
+autobump = true
 
 ["app-misc/crush"]
 source = "github"
@@ -385,6 +387,7 @@ source = "github"
 github = "google-antigravity/antigravity-cli"
 use_latest_release = true
 github_account = "zakkaus"
+autobump = true
 
 ["dev-util/cmakerc"]
 source = "github"
@@ -1135,6 +1138,7 @@ source = "regex"
 url = "https://prod.download.cli.kiro.dev/stable/latest/manifest.json"
 regex = '"version":\s*"([\d.]+)"'
 github_account = "zakkaus"
+autobump = true
 
 ["dev-util/maixvision"]
 source = "regex"


### PR DESCRIPTION
kiro、kiro-cli、antigravity-cli、copilot 的 SRC_URI 都是纯 ${PV}/${P}(prebuilt 纯滚版),bump 只需 rename + manifest,适合 autobump、CI 兜底。antigravity、antigravity-ide、cursor 因为 SRC_URI 带 per-version 的 build-id/commitSha,每版要手动改,维持手动。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.