### PR TITLE
emerge-on-pr: ignore eclass changes in the package matrix

### DIFF
--- a/.github/workflows/emerge-on-pr.yml
+++ b/.github/workflows/emerge-on-pr.yml
@@ -78,6 +78,7 @@ jobs:
             skel.ChangeLog
             skel.metadata.xml
             .github
+            eclass
             licenses
             metadata
             profiles


### PR DESCRIPTION
emerge-on-pr 把改动的 `eclass/<name>.eclass` 当成 package atom 丢给 emerge，报 "not a valid package atom" 直接红。加进 ignore_list（跟 scripts/metadata/profiles 同款）。eclass 改动由继承它的包来测。

overlay 现在开始有 eclass（dart-pub，见 #11351）。
