### PR TITLE
.github/workflows/autobump: switch commit sign-off to gentoo-zh-bot

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -159,7 +159,7 @@ jobs:
     - name: git identity
       run: |
         git config --global --add safe.directory "$(realpath .)"
-        git config user.name  "gentoozh-bot"
+        git config user.name  "gentoo-zh-bot"
         git config user.email "bot@gentoozh.org"
 
     - name: restore state


### PR DESCRIPTION
autobump 換了 bot 帳號,提交的 Signed-off-by 名字從 gentoozh-bot 改成 gentoo-zh-bot。email 不變。

---

Please check all the boxes that apply:

- [ ] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
