### PR TITLE
.github/workflows/overlay.toml: opt grok-build-bin into autobump

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1108,6 +1108,7 @@ source = "regex"
 url = "https://x.ai/cli/stable"
 regex = '^([\d.]+)$'
 github_account = "zakkaus"
+autobump = true
 
 ["dev-util/herdr-bin"]
 source = "github"


### PR DESCRIPTION
grok-build-bin 的 SRC_URI 纯 ${PV}(prebuilt 纯滚版),适合 autobump。(bilibili、claude-desktop、qwen-code 已经是 autobump。)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.