### PR TITLE
app-i18n/fcitx-quwei: new package, add 9999

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -513,6 +513,9 @@ github_account = "Linerre"
 # live package only
 #["app-i18n/fcitx-qt"]
 
+# upstream has no release, 9999 only
+#["app-i18n/fcitx-quwei"]
+
 # live package only
 #["app-i18n/fcitx-rime"]
 

--- a/app-i18n/fcitx-quwei/fcitx-quwei-9999.ebuild
+++ b/app-i18n/fcitx-quwei/fcitx-quwei-9999.ebuild
@@ -1,0 +1,25 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake git-r3 xdg
+
+MY_PN="fcitx5-quwei"
+DESCRIPTION="Quwei (区位) input method for Fcitx5"
+HOMEPAGE="https://github.com/fcitx/fcitx5-quwei"
+EGIT_REPO_URI="https://github.com/fcitx/${MY_PN}.git"
+
+LICENSE="BSD"
+SLOT="5"
+KEYWORDS=""
+
+DEPEND="
+	>=app-i18n/fcitx-5.1.0:5
+	app-i18n/fcitx-chinese-addons:5
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	kde-frameworks/extra-cmake-modules:0
+	sys-devel/gettext
+"

--- a/app-i18n/fcitx-quwei/metadata.xml
+++ b/app-i18n/fcitx-quwei/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>zakk@gentoozh.org</email>
+		<name>Zakk</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">fcitx/fcitx5-quwei</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
新增 fcitx5 区位输入法。上游没有 release，所以用 9999 live ebuild；因为它调用标点模块，所以依赖 `app-i18n/fcitx-chinese-addons` 提供的 `Fcitx5ModulePunctuation`。

#1580

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.