### PR TITLE
app-i18n/fcitx-fbterm: new package, add 9999

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -495,6 +495,9 @@ use_latest_release = true
 prefix = "v"
 github_account = "Linerre"
 
+# upstream has no release, 9999 only
+#["app-i18n/fcitx-fbterm"]
+
 # live package only
 #["app-i18n/fcitx-gtk"]
 

--- a/app-i18n/fcitx-fbterm/fcitx-fbterm-9999.ebuild
+++ b/app-i18n/fcitx-fbterm/fcitx-fbterm-9999.ebuild
@@ -1,0 +1,36 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake git-r3 xdg
+
+MY_PN="fcitx5-fbterm"
+DESCRIPTION="Fcitx5 input method frontend for fbterm"
+HOMEPAGE="https://github.com/fcitx/fcitx5-fbterm"
+EGIT_REPO_URI="https://github.com/fcitx/${MY_PN}.git"
+
+LICENSE="GPL-3+"
+SLOT="5"
+KEYWORDS=""
+
+DEPEND="
+	>=app-i18n/fcitx-5.1.0:5
+	app-i18n/fcitx-gtk:5
+	dev-libs/glib:2
+"
+RDEPEND="
+	${DEPEND}
+	app-i18n/fbterm
+"
+BDEPEND="
+	kde-frameworks/extra-cmake-modules:0
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	# Live upstream still declares cmake_minimum_required 3.6; raise it past
+	# ECM's compatibility threshold so it stops warning.
+	sed -i -e '/cmake_minimum_required/s/VERSION 3\.6/VERSION 3.16/' CMakeLists.txt || die
+	cmake_src_prepare
+}

--- a/app-i18n/fcitx-fbterm/metadata.xml
+++ b/app-i18n/fcitx-fbterm/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>zakk@gentoozh.org</email>
+		<name>Zakk</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">fcitx/fcitx5-fbterm</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
新增 fcitx5 的 fbterm(framebuffer 终端）输入前端。上游没有 release，所以用 9999 live ebuild。因为上游 CMakeLists 声明 `cmake_minimum_required` 3.6，ECM 会告警，所以 `src_prepare` 用 `sed` 提升到 3.16。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.