### PR TITLE
app-i18n/fcitx-hallelujah: new package, add 9999

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -498,6 +498,9 @@ github_account = "Linerre"
 # live package only
 #["app-i18n/fcitx-gtk"]
 
+# upstream has no release, 9999 only
+#["app-i18n/fcitx-hallelujah"]
+
 # live package only
 #["app-i18n/fcitx-hangul"]
 

--- a/app-i18n/fcitx-hallelujah/fcitx-hallelujah-9999.ebuild
+++ b/app-i18n/fcitx-hallelujah/fcitx-hallelujah-9999.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cmake git-r3 xdg
+
+MY_PN="fcitx5-hallelujah"
+DESCRIPTION="English word-completion (prediction) input method for Fcitx5"
+HOMEPAGE="https://github.com/fcitx-contrib/fcitx5-hallelujah"
+EGIT_REPO_URI="https://github.com/fcitx-contrib/${MY_PN}.git"
+
+LICENSE="GPL-3"
+SLOT="5"
+KEYWORDS=""
+IUSE="test"
+RESTRICT="!test? ( test )"
+
+DEPEND="
+	>=app-i18n/fcitx-5.1.13:5[enchant]
+	dev-cpp/nlohmann_json
+	dev-libs/libfmt:=
+	dev-libs/marisa
+"
+RDEPEND="${DEPEND}"
+BDEPEND="
+	dev-libs/marisa[tools(+)]
+	kde-frameworks/extra-cmake-modules:0
+	sys-devel/gettext
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	# Live upstream declares cmake_minimum_required 3.6; raise it past ECM's
+	# compatibility threshold so it stops warning.
+	sed -i -e '/cmake_minimum_required/s/VERSION 3\.6/VERSION 3.16/' CMakeLists.txt || die
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DENABLE_TEST=$(usex test)
+	)
+	cmake_src_configure
+}

--- a/app-i18n/fcitx-hallelujah/metadata.xml
+++ b/app-i18n/fcitx-hallelujah/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>zakk@gentoozh.org</email>
+		<name>Zakk</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">fcitx-contrib/fcitx5-hallelujah</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
新增 fcitx5 英文单词补全（预测）输入法，来自 fcitx-contrib 社区。上游没有 release，所以用 9999 live ebuild。词典（google 词频、cedict）随仓库提供，构建期用 marisa-build 生成，无网络下载。

#1580

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.