### PR TITLE
dev-util/trae-ide: remove bundled musl koffi.node

### DIFF
--- a/dev-util/trae-ide/trae-ide-2.3.59356-r1.ebuild
+++ b/dev-util/trae-ide/trae-ide-2.3.59356-r1.ebuild
@@ -76,6 +76,7 @@ src_install() {
 	rm -f \
 		"${ED}"/usr/share/trae-cn/resources/app/extensions/byted-icube.integrations-extended/dist/skia.linux-x64-musl.node \
 		"${ED}"/usr/share/trae-cn/resources/app/node_modules/@aha-kit/ipc-linux-x64/dist/zeromq/prebuild/linux/x64/node/musl-127-Release/addon.node \
+		"${ED}"/usr/share/trae-cn/resources/app/extensions/byted-solo.builtin-mcp/node_modules/@koromix/koffi-linux-x64/musl_x64/koffi.node \
 		|| die
 	if [[ -d ${ED}/usr/share/appdata ]]; then
 		mv "${ED}"/usr/share/{appdata,metainfo} || die


### PR DESCRIPTION
因为上游 2.3.59356 新增的 `@koromix/koffi-linux-x64/musl_x64/koffi.node` 链接的是 musl libc，在 glibc 系统上无法加载，还会让 Portage 报未解析 soname 使 CI 变红，所以和已有的两个 musl blob 一样在 `src_install` 里删除。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
