### PR TITLE
package.mask: mask dev-lang/quickjs for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,3 +1,10 @@
+# Zakk <zakk@gentoozh.org> (2026-07-28)
+# Collides with ::gentoo's dev-libs/quickjs-ng over /usr/bin/qjs and /usr/bin/qjsc,
+# neither side blocks the other. Upstream stopped at 2024.01.13, quickjs-ng succeeds
+# it, and nothing depends on this.
+# Masked for removal in 2026-08-28
+dev-lang/quickjs
+
 # jinqiang zhang <peeweep@0x0.ee> (2026-07-14)
 # Looks like no one use this package for a long time
 # Masked for removal in 2026-08-14


### PR DESCRIPTION
因为它和 ::gentoo 的 `dev-libs/quickjs-ng` 都装 `/usr/bin/qjs` 与 `/usr/bin/qjsc` 且两侧都没有 blocker，所以后装的一方会覆盖先装的文件。上游停在 2024.01.13，quickjs-ng 是接手维护的分支，overlay 与 ::gentoo 都没有包依赖它。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
