### PR TITLE
overlay.toml: follow the dufs move to www-servers

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2542,13 +2542,6 @@ use_latest_tag = true
 prefix = "tlpui-"
 github_account = "xz-dev"
 
-["www-apps/dufs"]
-source = "github"
-github = "sigoden/dufs"
-use_latest_release = true
-prefix = "v"
-github_account = "Puqns67"
-
 ["www-apps/folo-bin"]
 source = "github"
 github = "RSSNext/Folo"
@@ -2584,6 +2577,13 @@ source = "github"
 github = "emikulic/darkhttpd"
 use_latest_tag = true
 prefix = "v"
+
+["www-servers/dufs"]
+source = "github"
+github = "sigoden/dufs"
+use_latest_release = true
+prefix = "v"
+github_account = "Puqns67"
 
 ["www-servers/miniserve"]
 source = "github"


### PR DESCRIPTION
因为 3a9d317c9 把这个包从 `www-apps/dufs` 移到了 `www-servers/dufs`，而版本追踪表还指着旧路径，nvchecker 就一直按已经不存在的原子报告可升级。www-servers/dufs 现在已经是 0.46.0。Closes #11445

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
