### PR TITLE
overlay.toml: drop tracking for the removed dev-python/pytube

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1071,13 +1071,6 @@ github = "Freed-Wu/pyrime"
 use_latest_release = true
 github_account = "Freed-Wu"
 
-["dev-python/pytube"]
-source = "github"
-github = "pytube/pytube"
-use_latest_tag = true
-prefix = "v"
-github_account = "wgjak47"
-
 ["dev-python/pywikibot"]
 source = "pypi"
 pypi = "pywikibot"


### PR DESCRIPTION
因为 b3ee15f66 已经把这个包从 overlay 移除，而版本追踪表还留着它的条目，nvchecker 就会按一个树里不存在的原子反复报告可升级。上游停更、接手的 pytubefix 也不在本 overlay，所以直接删掉条目而不是改指向。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
