### PR TITLE
package.mask: mask the packages ::gentoo already carries

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -1,4 +1,17 @@
 # Zakk <zakk@gentoozh.org> (2026-07-28)
+# ::gentoo carries the same version or a newer one, with keywords at least as wide,
+# and nothing here needs this copy: every consumer depends on a plain atom that the
+# ::gentoo version satisfies. Keeping them only splits maintenance.
+# Masked for removal in 2026-08-28
+dev-libs/libdatrie
+dev-libs/libratbag
+dev-libs/libthai
+gui-libs/libdecor
+media-fonts/smiley-sans
+media-video/amdgpu-pro-amf
+sys-fs/jmtpfs
+
+# Zakk <zakk@gentoozh.org> (2026-07-28)
 # Collides with ::gentoo's dev-libs/quickjs-ng over /usr/bin/qjs and /usr/bin/qjsc,
 # neither side blocks the other. Upstream stopped at 2024.01.13, quickjs-ng succeeds
 # it, and nothing depends on this.


### PR DESCRIPTION
因为这七个包 ::gentoo 都有同版本或更新的一份、KEYWORDS 覆盖不比 overlay 窄，而 overlay 内部引用它们的原子都不带版本、::gentoo 那份即可满足，所以停止在本 overlay 维护第二份。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
