### PR TITLE
dev-util/kimi-code-bin: add nvchecker

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1116,6 +1116,14 @@ use_latest_release = true
 github_account = "liangyongxiang"
 autobump = true
 
+["dev-util/kimi-code-bin"]
+source = "github"
+github = "MoonshotAI/kimi-code"
+use_latest_release = true
+prefix = "@moonshot-ai/kimi-code@"
+github_account = "vowstar"
+autobump = true
+
 ["dev-util/kiro-cli"]
 source = "regex"
 url = "https://prod.download.cli.kiro.dev/stable/latest/manifest.json"


### PR DESCRIPTION
Track upstream releases so nvchecker can file bump issues. Verified locally that the entry resolves to the latest upstream release.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.