### PR TITLE
ci: emerge: add gentoo-zh binhost

### DIFF
--- a/.github/workflows/emerge-on-pr.yml
+++ b/.github/workflows/emerge-on-pr.yml
@@ -161,7 +161,7 @@ jobs:
     - name: setup repo
       run: |
         mkdir -p /etc/portage/repos.conf
-        cat > /etc/portage/repos.conf/repo.conf << EOF
+        cat > /etc/portage/repos.conf/ci.conf << EOF
         [$(cat profiles/repo_name)]
         location = $(realpath .)
         priority = 0
@@ -170,20 +170,34 @@ jobs:
     - name: setup portage config
       run: |
         cat >> /etc/portage/make.conf << EOF
-        FEATURES="\${FEATURES} getbinpkg"
         MAKEOPTS="\${MAKEOPTS} -j$(nproc)"
         PORTAGE_ELOG_CLASSES="qa warn error"
         PORTAGE_ELOG_SYSTEM="save"
+        FETCHCOMMAND="\${FETCHCOMMAND} --no-verbose"
+        RESUMECOMMAND="\${RESUMECOMMAND} --no-verbose"
         EOF
+
+        cat > /etc/portage/binrepos.conf/ci.conf << EOF
+        [$(cat profiles/repo_name)-binhost]
+        sync-uri = https://distfiles.gentoozh.org/binpkgs/x86-64
+        priority = 2
+        EOF
+
         mkdir -p /etc/portage/package.use
-        cat >> /etc/portage/package.use/ci-binhost << EOF
+        cat > /etc/portage/package.use/ci << EOF
         dev-qt/qtwebengine bindist
         net-libs/webkit-gtk keyring
         EOF
+
         cat /etc/portage/make.conf
 
     - name: setup keyring for binpkgs
-      run: getuto
+      run: |
+        getuto
+        export GNUPGHOME=/etc/portage/gnupg
+        wget -qO - https://distfiles.gentoozh.org/gentoo-zh-binhost.asc | gpg --import
+        gpg --batch --yes --pinentry-mode loopback --passphrase-file "${GNUPGHOME}/pass" --lsign-key 6A0726AF1476A2F382C6AC6638A0234EC16AD42E
+        gpg --batch --check-trustdb
 
     - name: setup distfiles permissions
       run: |
@@ -192,7 +206,7 @@ jobs:
 
     - name: emerge --onlydeps packages
       run: |
-        emerge --quiet --autounmask=y --autounmask-write=y --autounmask-continue=y --onlydeps ${{ matrix.target.package }}
+        FEATURES="getbinpkg" emerge --onlydeps --jobs 2 --quiet --verbose --autounmask=y --autounmask-write=y --autounmask-continue=y ${{ matrix.target.package }}
         rm -rf /var/log/portage/elog/*
 
     - name: emerge packages


### PR DESCRIPTION
给测试 ci 添加 gentoo-zh 自己的 binhost (@Zakkaus 提供)
顺带缩减了一下 fetch 产生的 log，给 fetchonly 的命令加上 verbose。

应用此 PR 之前：https://github.com/gentoo-zh/overlay/actions/runs/30275369922/job/90008002519
用时：34 分钟 2 秒

应用此 PR 之后：https://github.com/gentoo-zh/overlay/actions/runs/30430806459/job/90507421072
用时：10 分钟 16 秒

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
