### PR TITLE
README: document the binary package host

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ It is recommended to run `pkgdev commit` to quickly generate commit messages.
 
 * Run `pkgcheck scan --commits --net` locally before you open pull request.
 
+# Binary packages
+
+Part of the overlay ships as prebuilt binary packages, rebuilt and signed nightly.
+Setup, including the signing key import, is at https://distfiles.gentoozh.org
+
 # Distfiles mirror
 
 We provide a distfiles mirror that caches the distfiles in gentoo-zh.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,6 +74,11 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 
 * 在打开 pull request 前，请先在本地运行 `pkgcheck scan --commits --net`。
 
+# 二进制包
+
+overlay 的一部分包提供预编译的二进制包，每晚重新构建并签名。
+配置方式（含签名公钥导入）见 https://distfiles.gentoozh.org
+
 # Distfiles 镜像
 
 我们提供 distfiles 镜像，用于缓存 gentoo-zh 的 distfiles。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -74,6 +74,11 @@ https://github.com/gentoo-zh/overlay/blob/deps-table/relation.md
 
 * 在開啟 pull request 前，請先在本機執行 `pkgcheck scan --commits --net`。
 
+# 二進位套件
+
+overlay 的一部分套件提供預先編譯的二進位套件，每晚重新建置並簽名。
+設定方式（含簽章公鑰匯入）見 https://distfiles.gentoozh.org
+
 # Distfiles 鏡像
 
 我們提供 distfiles 鏡像，用於快取 gentoo-zh 的 distfiles。


### PR DESCRIPTION
overlay 的一部分包现在有预编译的二进制包，三份 README 各加一段指向 https://distfiles.gentoozh.org 上的配置说明。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.