### PR TITLE
.github/workflows: pkgcheck: comment scan results for changed packages

### DIFF
--- a/.github/workflows/pkgcheck-comment.yml
+++ b/.github/workflows/pkgcheck-comment.yml
@@ -1,0 +1,106 @@
+# Posts the report that the pkgcheck workflow's `report` job leaves behind.
+#
+# It has to be a second workflow: the scan runs code from the pull request, so it only
+# ever gets a read-only token and cannot comment on a fork PR. workflow_run runs from
+# master with the base repository's permissions and never checks the PR out.
+name: pkgcheck-comment
+on:
+  workflow_run:
+    workflows: [pkgcheck]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download the report
+      uses: actions/download-artifact@v7
+      with:
+        name: pkgcheck-report
+        path: pkgcheck-report
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Post the report
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        RUN_URL: ${{ github.event.workflow_run.html_url }}
+      run: |
+        set -euo pipefail
+        MARKER='<!-- pkgcheck-report -->'
+
+        # the artifact is written by a job running pull request code, so resolve the PR
+        # from the head commit instead of trusting anything inside it
+        pr=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number // empty')
+        [ -n "${pr}" ] || { echo 'no pull request for this run'; exit 0; }
+
+        count=$(wc -l < pkgcheck-report/packages)
+        [ "${count}" -gt 0 ] || { echo 'no packages touched'; exit 0; }
+        commit=$(cat pkgcheck-report/commit)
+        # findings are indented under a package name, package names are not
+        new=$(grep -c '^  ' pkgcheck-report/new.txt || true)
+        existing=$(( $(grep -c '^  ' pkgcheck-report/report.txt || true) - new ))
+
+        plural() { [ "$1" -eq 1 ] && echo "$2" || echo "$2s"; }
+
+        {
+          echo '## Pull request pkgcheck report'
+          echo
+          echo "*Newest commit scanned*: \`${commit}\`"
+          if [ "${count}" -le 10 ]; then
+            echo "*Packages scanned*: $(sed 's/^/`/; s/$/`/' pkgcheck-report/packages | paste -sd ' ' -)"
+          else
+            echo "*Packages scanned*: ${count}"
+          fi
+          if [ "${new}" -eq 0 ]; then
+            echo '*Status*: :white_check_mark: good'
+          else
+            # not :x: broken like gentoo-repo-qa-bot: these findings do not fail CI
+            echo '*Status*: :warning: **new issues**'
+            echo
+            # a long list buries the rest of the comment, so fold it away
+            if [ "${new}" -gt 10 ]; then
+              echo "<details><summary>New issues caused by PR (${new})</summary>"
+              echo
+              close='</details>'
+            else
+              echo 'New issues caused by PR:'
+              echo
+              close=''
+            fi
+            # a long fence so a finding that quotes markdown cannot end the block early
+            echo '``````'
+            if [ "$(wc -c < pkgcheck-report/new.txt)" -le 55000 ]; then
+              cat pkgcheck-report/new.txt
+            else
+              # head -c cuts mid-line, so drop the partial one it leaves behind
+              head -c 55000 pkgcheck-report/new.txt | head -n -1
+              echo '[truncated, see the full report]'
+            fi
+            echo '``````'
+            [ -z "${close}" ] || { echo; echo "${close}"; }
+          fi
+          if [ "${existing}" -gt 0 ]; then
+            echo
+            echo "There are ${existing} existing $(plural "${existing}" issue) in these packages. Please look"
+            echo "into the [full report](${RUN_URL}) to make sure none of them affect your change."
+          fi
+          echo
+          echo "${MARKER}"
+        } > body.md
+
+        # one comment per PR, edited in place, so a rerun does not add another
+        id=$(gh api "repos/${REPO}/issues/${pr}/comments" --paginate \
+             --jq "map(select(.body|contains(\"${MARKER}\")))|.[0].id // empty")
+        if [ -n "${id}" ]; then
+          gh api -X PATCH "repos/${REPO}/issues/comments/${id}" -F body=@body.md >/dev/null
+        else
+          gh api "repos/${REPO}/issues/${pr}/comments" -F body=@body.md >/dev/null
+        fi
+        echo "commented on #${pr}"

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -19,3 +19,102 @@ jobs:
       uses: pkgcore/pkgcheck-action@v1
       with:
         args: --checks=-RedundantVersionCheck --keywords=-NonsolvableDepsInDev --exit=NonexistentDeps
+
+  # Scan only the packages the PR touches and leave the report for pkgcheck-comment
+  # to post. The job above fails on NonexistentDeps alone, so a warning-level finding
+  # on a changed ebuild is invisible unless someone opens the run log.
+  #
+  # This job must never hold a write token. pkgcheck sources the ebuilds it scans, so
+  # it runs code from the pull request; on a fork PR GITHUB_TOKEN is read-only and the
+  # comment is posted from a separate workflow that does not check this code out.
+  report:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/pkgcore/pkgcheck:latest
+    defaults:
+      run:
+        # the image has no /bin/bash symlink, so GitHub falls back to sh
+        shell: bash
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Collect the packages this PR touches
+      id: pkgs
+      run: |
+        set -euo pipefail
+        git config --global --add safe.directory '*'
+        # checkout leaves the pull request's merge ref here: parent 1 is the base branch
+        # tip, parent 2 is the PR head. Diff between them for the PR's own changes.
+        # pull_request.base.sha is the base tip from when the PR was opened, so once
+        # master moves the packages merged since would be counted as this PR's.
+        git diff --name-only --diff-filter=d 'HEAD^1...HEAD^2' \
+          | awk -F/ 'NF > 2 { print $1"/"$2 }' | sort -u > touched.txt
+        # gentoo-zh carries no profiles/categories, so decide by what is on disk: a
+        # touched path is a package only if the directory still holds ebuilds. That
+        # drops .github/, profiles/ and a package the PR removed outright.
+        : > packages.txt
+        while read -r pkg; do
+          ls "${pkg}"/*.ebuild >/dev/null 2>&1 || continue
+          echo "${pkg}" >> packages.txt
+        done < touched.txt
+        echo "count=$(wc -l < packages.txt)" >> "$GITHUB_OUTPUT"
+        cat packages.txt
+
+    - name: Scan
+      if: steps.pkgs.outputs.count != '0'
+      run: |
+        set -uo pipefail
+        pmaint sync gentoo
+        head=$(git rev-parse HEAD)
+
+        scan() {  # $1 report path, rest packages; no --exit, the gate is the build job
+          local out=$1
+          shift
+          pmaint regen --dir ~/.cache/pkgcheck/repos . > /dev/null
+          pkgcheck scan --checks=-RedundantVersionCheck --keywords=-NonsolvableDepsInDev \
+            "$@" > "${out}" 2>&1 || true
+        }
+
+        # package names come from the pull request, so keep them out of the command line
+        mapfile -t pkgs < packages.txt
+        scan report.txt "${pkgs[@]}"
+
+        # scan the base branch tip too, so a finding the pull request did not introduce
+        # can be told from one it did; a package the PR adds is absent here, which
+        # leaves all of its findings new
+        git checkout --quiet 'HEAD^1'
+        : > base-report.txt
+        mapfile -t base_pkgs < <(
+          for pkg in "${pkgs[@]}"; do
+            ls "${pkg}"/*.ebuild > /dev/null 2>&1 && echo "${pkg}"
+          done
+        )
+        [ "${#base_pkgs[@]}" -eq 0 ] || scan base-report.txt "${base_pkgs[@]}"
+        git checkout --quiet "${head}"
+
+        python3 scripts/pkgcheck-new-findings.py base-report.txt report.txt > new.txt
+        echo '--- new ---'; cat new.txt
+        echo '--- all ---'; cat report.txt
+
+    - name: Stage the report
+      if: always()
+      run: |
+        set -euo pipefail
+        mkdir -p pkgcheck-report
+        # the head of the pull request, not the merge commit, so the comment names a
+        # commit the author can see in the branch
+        git rev-parse --short 'HEAD^2' > pkgcheck-report/commit
+        cp packages.txt pkgcheck-report/packages 2>/dev/null || : > pkgcheck-report/packages
+        cp report.txt pkgcheck-report/report.txt 2>/dev/null || : > pkgcheck-report/report.txt
+        cp new.txt pkgcheck-report/new.txt 2>/dev/null || : > pkgcheck-report/new.txt
+
+    - name: Upload the report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: pkgcheck-report
+        path: pkgcheck-report/

--- a/scripts/pkgcheck-new-findings.py
+++ b/scripts/pkgcheck-new-findings.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Print the pkgcheck findings a pull request adds, dropping the ones already there.
+
+pkgcheck plain output puts a package on its own line and indents its findings under
+it. Findings are matched by package, keyword and version rather than by the whole
+message, so one that merely moved to another line does not count as new.
+
+Usage: pkgcheck-new-findings.py BASE_REPORT HEAD_REPORT
+"""
+
+import sys
+
+
+def parse(path):
+    """Map (package, keyword, version) to the finding as pkgcheck printed it."""
+    findings = {}
+    package = None
+    with open(path) as report:
+        for line in report:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            if not line.startswith(" "):
+                package = line
+                continue
+            keyword, _, rest = line.strip().partition(": ")
+            version = rest.split(":")[0] if rest.startswith("version ") else ""
+            findings[(package, keyword, version)] = line
+    return findings
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(__doc__)
+    existing = parse(sys.argv[1])
+    added = {key: line for key, line in parse(sys.argv[2]).items() if key not in existing}
+
+    package = None
+    for (pkg, _, _), line in added.items():
+        if pkg != package:
+            if package is not None:
+                print()
+            print(pkg)
+            package = pkg
+        print(line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
因为仓库级扫描只在 NonexistentDeps 上失败，所以改动的 ebuild 上 warning 级别的问题
不会让 CI 变红。

因为 pkgcheck 会 source 它扫描的 ebuild，等于执行 PR 里的代码，所以扫描只拿只读
token，评论由 workflow_run 另起一个不检出该代码的任务发出。

因为包里原有的问题会淹没 PR 引入的那几条，所以基线分支也扫一遍，评论只列新增的。

Closes #11479

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
