### PR TITLE
autobump: opt in dev-util/trae-ide

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1207,6 +1207,7 @@ source = "regex"
 url = "https://api.trae.cn/icube/api/v1/native/version/trae/cn/latest"
 regex = 'releases/stable/([\d.]+)/'
 github_account = "microcai"
+autobump = true
 
 ["dev-util/vcpkg-tool"]
 source = "github"


### PR DESCRIPTION
因为它的 SRC_URI 用 `${PV}` 拼路径、没有 patch 也没有 vendor 目录，版本跳动只有 build number，所以 bump 是纯机械的。

唯一会变的是上游偶尔新增 musl 的 `.node` blob，需要在 `src_install` 里跟着删；因为这类 blob 会让 Portage 报未解析 soname 使 CI 变红，所以 autobump 会 escalate 而不是合进来，2.3.59356 的 `koffi.node` 就是这么发现的。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
