### PR TITLE
.github/workflows: nvchecker: scope trae-ide to the linux release

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1205,7 +1205,10 @@ github_account = "liangyongxiang"
 ["dev-util/trae-ide"]
 source = "regex"
 url = "https://api.trae.cn/icube/api/v1/native/version/trae/cn/latest"
-regex = 'releases/stable/([\d.]+)/'
+# The response also carries a separate product (data.solo, TRAE_Work_CN) that is
+# released for darwin and win32 only. Match the linux path so its version cannot
+# be reported as an update we have no download for.
+regex = 'releases/stable/([\d.]+)/linux/'
 github_account = "microcai"
 autobump = true
 


### PR DESCRIPTION
Closes #11517

#11517 报的 2.3.61402 不是 trae-ide 的新版本。版本 API 的响应里还有另一个产品
（`data.solo`，TRAE_Work_CN），只发布 darwin 和 win32。原来的 regex 扫整份响应，
把它的版本报成更新，而对应的 linux deb 在 CDN 上是 404：

```
https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable//2.3.61402/linux/Trae_CN-linux-x64.deb 403
https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/2.3.59356/linux/Trae_CN-linux-x64.deb 200
```

收窄到 `releases/stable/([\d.]+)/linux/` 后实跑 nvchecker，把 oldver 设成 1.0.0 验证能取到版本：

    dev-util/trae-ide: updated from 1.0.0 to 2.3.59356

CC @microcai 
---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.