### PR TITLE
.github/workflows: pkgcheck: fix the pull request comment

### DIFF
--- a/.github/workflows/pkgcheck-comment.yml
+++ b/.github/workflows/pkgcheck-comment.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   comment:
+    if: github.event.workflow_run.event == 'pull_request'  # a push has no artifact
     runs-on: ubuntu-latest
     steps:
     - name: Download the report
@@ -35,10 +36,12 @@ jobs:
         set -euo pipefail
         MARKER='<!-- pkgcheck-report -->'
 
-        # the artifact is written by a job running pull request code, so resolve the PR
-        # from the head commit instead of trusting anything inside it
-        pr=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number // empty')
-        [ -n "${pr}" ] || { echo 'no pull request for this run'; exit 0; }
+        # commits/{sha}/pulls returns nothing for a fork PR; the artifact is not trusted
+        matches=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
+                  --jq ".[]|select(.head.sha==\"${HEAD_SHA}\")|.number")
+        pr=${matches%%$'\n'*}  # not `| head -1`: pipefail turns the early close into a failure
+        [ -n "${pr}" ] || { echo 'no open pull request at this commit'; exit 0; }
+        echo "pull request #${pr}"
 
         count=$(wc -l < pkgcheck-report/packages)
         [ "${count}" -gt 0 ] || { echo 'no packages touched'; exit 0; }


### PR DESCRIPTION
因为 commits/{sha}/pulls 对来自 fork 的 pull request 返回空，而这里的 pull request
都来自 fork，所以评论一次也没发出去。改成拿 head sha 去匹配开着的 pull request。

因为 workflow_run 对 master 上的 push 也会触发，而那种 run 里 report 任务被跳过、
没有 artifact，所以下载那步失败，每次合并都留一个红的 run。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
