### PR TITLE
.github/workflows: nvchecker: track cachyos-sources by max tag

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2553,7 +2553,8 @@ github_account = "gouwazi"
 ["sys-kernel/cachyos-sources"]
 source = "github"
 github = "CachyOS/linux"
-use_latest_release = true
+use_max_tag = true
+include_regex = "cachyos-[0-9.]+-[0-9]+"
 from_pattern = "cachyos-([0-9.]+)-[0-9]+"
 to_pattern = "\\1"
 github_account = ["blackteahamburger", "Zakkaus", "locez"]


### PR DESCRIPTION
7.1.5 从 2026-07-25 起就在了，但一直没被报出来。

`use_latest_release` 只看 GitHub 标为 latest 的那一个 release，现在是 `cachyos-7.2-rc5-1`。
CachyOS 同时维护 7.2-rc、7.1.x、6.18.x 三条线，而且 rc 没有标 prerelease，所以最新的 rc 占了
那个位置。接着 `from_pattern` 匹配不上它，nvchecker 不报错、把原始 tag 当版本号留下，于是静默
不报。

改成 `use_max_tag` 扫全部 release，用 `include_regex` 排掉 rc。

    改前：sys-kernel/cachyos-sources -> cachyos-7.2-rc5-1（不报）
    改后：sys-kernel/cachyos-sources 7.1.4 -> 7.1.5

只改追踪配置，不含 bump——kernel 包交维护者（CC 已在条目里）。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.