### PR TITLE
.github/workflows: nvchecker: track liquorix-sources by max tag

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -2561,7 +2561,8 @@ github_account = ["blackteahamburger", "Zakkaus", "locez"]
 ["sys-kernel/liquorix-sources"]
 source = "github"
 github = "zen-kernel/zen-kernel"
-use_latest_release = true
+use_max_tag = true
+include_regex = "v[0-9.]+-lqx[0-9]+"
 from_pattern = "v(.*)-lqx(.*)"
 to_pattern = "\\1"
 github_account = ["zozx", "gouwazi"]


### PR DESCRIPTION
`use_latest_release` 只看 GitHub 标为 latest 的那一个 release。zen-kernel 在同一个 repo 里
同时发 `-zen` 和 `-lqx`，那个位置现在是 `v7.1.5-zen1`，`from_pattern` 匹配不上它。nvchecker
匹配失败时不报错、把原始 tag 当版本号留下，于是从来没报过——`v7.1.5-lqx1` 早就发布了。

改成 `use_max_tag` 扫全部 release，用 `include_regex` 只留 lqx 那条线。

    改前：sys-kernel/liquorix-sources -> v7.1.5-zen1（不报）
    改后：sys-kernel/liquorix-sources 7.1.3 -> 7.1.5

同类问题的 cachyos-sources 在 #11552。把 overlay.toml 里全部 22 个 from_pattern 条目跑过一遍
nvchecker，20 个有回报，只有这两个的 pattern 没生效。

只改追踪配置，不含 bump——kernel 包交维护者（CC 已在条目里）。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.