### PR TITLE
.github/workflows: nvchecker: drop autobump for grok-build-bin

### DIFF
--- a/.github/workflows/overlay.toml
+++ b/.github/workflows/overlay.toml
@@ -1234,7 +1234,6 @@ source = "regex"
 url = "https://x.ai/cli/stable"
 regex = '^([\d.]+)$'
 github_account = "zakkaus"
-autobump = true
 
 ["dev-util/herdr-bin"]
 source = "github"


### PR DESCRIPTION
每次 bump 都会 escalate，人工每次用同样方式解决。手动做成本相同，sweep 名额留给能跑完的包。

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.