### PR TITLE
*/*: add RESTRICT=bindist where the license forbids redistribution

### DIFF
--- a/media-fonts/harmonyos-sans/harmonyos-sans-5.0.1.ebuild
+++ b/media-fonts/harmonyos-sans/harmonyos-sans-5.0.1.ebuild
@@ -15,6 +15,6 @@ SLOT="0"
 KEYWORDS="~amd64 ~arm64 ~loong ~riscv ~x86"
 
 FONT_SUFFIX="ttf"
-RESTRICT="mirror"
+RESTRICT="bindist mirror"
 
 BDEPEND="app-arch/unzip"

--- a/media-fonts/misans/misans-4.003-r1.ebuild
+++ b/media-fonts/misans/misans-4.003-r1.ebuild
@@ -18,7 +18,7 @@ KEYWORDS="~amd64"
 BDEPEND="app-arch/unzip"
 FONT_SUFFIX="otf ttf"
 
-RESTRICT="mirror"
+RESTRICT="bindist mirror"
 
 src_unpack() {
 	unpack "${A}"

--- a/media-sound/harmonoid/harmonoid-0.3.32.ebuild
+++ b/media-sound/harmonoid/harmonoid-0.3.32.ebuild
@@ -19,6 +19,7 @@ S="${WORKDIR}"
 LICENSE="harmonoid-EULA"
 SLOT="0"
 KEYWORDS="-* ~amd64 ~arm64"
+RESTRICT="bindist mirror"
 
 QA_PRESTRIPPED="usr/share/harmonoid/lib/libapp.so"
 

--- a/sci-chemistry/vesta/vesta-3.5.8.ebuild
+++ b/sci-chemistry/vesta/vesta-3.5.8.ebuild
@@ -15,7 +15,7 @@ LICENSE="VESTA"
 SLOT="0"
 KEYWORDS="~amd64"
 
-RESTRICT="mirror strip"
+RESTRICT="bindist mirror strip"
 
 RDEPEND="
 	x11-libs/gtk+:3[wayland]


### PR DESCRIPTION
因为 harmonoid-EULA、MiSans、HarmonyOS-Sans 和 VESTA 都明文禁止单独再散布软件本体，而缺少 `RESTRICT=bindist` 会让构建出的二进制包被当作可以散布，所以为这四个包补上；`media-sound/harmonoid` 原本没有任何 `RESTRICT`，一并补上 `mirror`。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
