### PR TITLE
app-misc/bilihud: update 9999

### DIFF
--- a/app-misc/bilihud/bilihud-9999.ebuild
+++ b/app-misc/bilihud/bilihud-9999.ebuild
@@ -3,54 +3,61 @@
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=hatchling
 DISTUTILS_EXT=1
+DISTUTILS_USE_PEP517=scikit-build-core
 PYTHON_COMPAT=( python3_{13..14} )
 
-inherit desktop distutils-r1 git-r3
+inherit distutils-r1 desktop git-r3
 
-DESCRIPTION="Bilibili danmaku overlay for fullscreen games"
+DESCRIPTION="B站弹幕阅读器 - 一个可以在游戏全屏时显示弹幕的Qt应用程序"
 HOMEPAGE="https://github.com/locez/bilihud"
 EGIT_REPO_URI="https://github.com/locez/bilihud.git"
 EGIT_SUBMODULES=( '*' )
 
-LICENSE="MIT"
-SLOT="0"
-
-RDEPEND="
-	app-arch/brotli[python,${PYTHON_USEDEP}]
-	dev-python/aiohttp[${PYTHON_USEDEP}]
-	dev-python/browser-cookie3[${PYTHON_USEDEP}]
-	dev-python/keyring[${PYTHON_USEDEP}]
-	dev-python/pillow[${PYTHON_USEDEP}]
-	dev-python/pure-protobuf[${PYTHON_USEDEP}]
-	dev-python/pyqt6[${PYTHON_USEDEP}]
-	dev-python/qasync[${PYTHON_USEDEP}]
-	dev-python/qrcode[${PYTHON_USEDEP}]
-	dev-qt/qtbase:6
-	dev-qt/qtwayland:6
-	kde-plasma/layer-shell-qt
-"
-
 EPYTEST_PLUGINS=()
 distutils_enable_tests pytest
 
-python_prepare_all() {
-	sed -i \
-		-e '/hatch-build-scripts/d' \
-		-e '/\[tool.hatch.build.hooks.build-scripts\]/,/artifacts =/d' \
-		pyproject.toml || die
+LICENSE="MIT"
+SLOT="0"
 
-	distutils-r1_python_prepare_all
-}
+DEPEND="
+	dev-libs/wayland:=
+	dev-qt/qtbase:6=[gui,wayland]
+	kde-plasma/layer-shell-qt:6=
+"
 
-src_compile() {
-	./src/bilihud/build_bridge.sh || die
-	distutils-r1_src_compile
+RDEPEND="${DEPEND}
+	dev-qt/qtwayland:6
+	dev-python/pyqt6[${PYTHON_USEDEP}]
+	dev-python/aiohttp[${PYTHON_USEDEP}]
+	dev-python/qasync[${PYTHON_USEDEP}]
+	app-arch/brotli[python,${PYTHON_USEDEP}]
+	dev-python/pure-protobuf[${PYTHON_USEDEP}]
+	dev-python/qrcode[${PYTHON_USEDEP}]
+	dev-python/keyring[${PYTHON_USEDEP}]
+	dev-python/pillow[${PYTHON_USEDEP}]
+"
+
+BDEPEND="
+	dev-build/cmake
+	dev-build/ninja
+	virtual/pkgconfig
+"
+
+python_configure_all() {
+	DISTUTILS_ARGS=(
+		-DBILIHUD_INSTALL_DIR=bilihud
+		-DBILIHUD_LAYER_SHELL=ON
+	)
 }
 
 python_install_all() {
 	distutils-r1_python_install_all
 	domenu bilihud.desktop
 	newicon src/bilihud/assets/icon.png bilihud.png
+}
+
+python_test() {
+	local -x QT_QPA_PLATFORM=offscreen
+	epytest
 }


### PR DESCRIPTION
因为上游将构建后端改为 `scikit_build_core.build` 并把 Layer Shell bridge 纳入 CMake，所以更新 ebuild 的构建后端、依赖和安装参数。

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.
- [x] If I used AI: it followed AGENTS.md, I checked and tested its output, and the description shows tested results, not guesses.

Please note that all boxes must be checked for the pull request to be merged.
